### PR TITLE
Profile - Personal attributes name custom configuration

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/beans/Locale.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/beans/Locale.java
@@ -1,0 +1,25 @@
+package cz.metacentrum.perun.wui.client.resources.beans;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Vojtech Sassmann <vojtech.sassmann@gmail.com>
+ */
+public enum Locale {
+	CS,
+	EN;
+
+	private static Map<String, Locale> values;
+
+	static {
+		values = new HashMap<>();
+		for (Locale locale : Locale.values()) {
+			values.put(locale.toString().toLowerCase(), locale);
+		}
+	}
+
+	public static Locale fromString(String string) {
+		return values.get(string.trim().toLowerCase());
+	}
+}

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/beans/PersonalAttribute.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/beans/PersonalAttribute.java
@@ -11,7 +11,8 @@ import java.util.Map;
 public class PersonalAttribute {
 
 	private String urn;
-	private Map<String, String> localizedDescriptions = new HashMap<>();
+	private Map<Locale, String> localizedDescriptions = new HashMap<>();
+	private Map<Locale, String> localizedNames = new HashMap<>();
 
 	public String getUrn() {
 		return urn;
@@ -21,21 +22,35 @@ public class PersonalAttribute {
 		this.urn = urn;
 	}
 
-	public void addDescription(String language, String description) {
-		this.localizedDescriptions.put(language, description);
+	public void addDescription(Locale locale, String description) {
+		this.localizedDescriptions.put(locale, description);
 	}
 
-	public Map<String, String> getLocalizedDescriptions() {
+	public Map<Locale, String> getLocalizedDescriptions() {
 		return localizedDescriptions;
 	}
 
-	public String getLocalizedDescription(String locale) {
-		for (String descriptionLocale : localizedDescriptions.keySet()) {
-			if (locale.contains(descriptionLocale)) {
+	public void addName(Locale locale, String description) {
+		this.localizedNames.put(locale, description);
+	}
+
+	public String getLocalizedName(Locale locale) {
+		for (Locale nameLocale : localizedNames.keySet()) {
+			if (locale == nameLocale) {
+				return localizedNames.get(nameLocale);
+			}
+		}
+
+		return null;
+	}
+
+	public String getLocalizedDescription(Locale locale) {
+		for (Locale descriptionLocale : localizedDescriptions.keySet()) {
+			if (locale == descriptionLocale) {
 				return localizedDescriptions.get(descriptionLocale);
 			}
 		}
 
-		return "";
+		return null;
 	}
 }

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/utils/Utils.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/utils/Utils.java
@@ -11,11 +11,19 @@ import com.google.gwt.user.client.Cookies;
 import com.google.gwt.user.client.Window;
 import cz.metacentrum.perun.wui.client.resources.PerunConfiguration;
 import cz.metacentrum.perun.wui.client.resources.PerunSession;
+import cz.metacentrum.perun.wui.client.resources.beans.Locale;
 import cz.metacentrum.perun.wui.model.beans.Vo;
 import org.gwtbootstrap3.extras.animate.client.ui.constants.Animation;
 import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
 
 /**
  * Class with support methods used in GUI code
@@ -1452,12 +1460,17 @@ public class Utils {
 	}
 
 	/**
-	 * Returns content of element meta-lang withou the starting "locale=" string
+	 * Returns Locale parsed from element meta-lang. If there is unknown locale, EN is returned.
 	 *
-	 * @return
+	 * @return Locale
 	 */
-	public static String getLocale() {
+	public static Locale getLocale() {
 		Element ele = Document.get().getElementById("meta-lang");
-		return ele.getAttribute("content").replace("locale=", "");
+		String localeString = ele.getAttribute("content").replace("locale=", "");
+		Locale locale = Locale.fromString(localeString);
+		if (locale == null) {
+			locale = Locale.EN;
+		}
+		return locale;
 	}
 }

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
@@ -282,37 +282,39 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 		Span descriptionSpan = new Span();
 		Text textEl = new Text();
 
-		for (String s : text.split("\\s+")) {
-			// if the given substring is link
-			if (s.startsWith("http")) {
-				descriptionSpan.add(textEl);
-				textEl = new Text(" ");
+		if (text != null) {
+			for (String s : text.split("\\s+")) {
+				// if the given substring is link
+				if (s.startsWith("http")) {
+					descriptionSpan.add(textEl);
+					textEl = new Text(" ");
 
-				String href;
-				String hrefText;
-				// check if the link contains text
-				if (s.trim().matches(".*\\{.*}.*")) {
-					String[] split = s.split("}");
+					String href;
+					String hrefText;
+					// check if the link contains text
+					if (s.trim().matches(".*\\{.*}.*")) {
+						String[] split = s.split("}");
 
-					// append the text after the link text
-					if (split.length > 1) {
-						textEl.setText("");
-						for(int i = 1; i < split.length; i++) {
-							textEl.setText(textEl.getText() + split[i]);
+						// append the text after the link text
+						if (split.length > 1) {
+							textEl.setText("");
+							for(int i = 1; i < split.length; i++) {
+								textEl.setText(textEl.getText() + split[i]);
+							}
 						}
+
+						split = s.split("\\{");
+
+						href = split[0];
+						hrefText = split[1].substring(0, split[1].indexOf("}"));
+					} else {
+						href = s;
+						hrefText = s;
 					}
-
-					split = s.split("\\{");
-
-					href = split[0];
-					hrefText = split[1].substring(0, split[1].indexOf("}"));
+					descriptionSpan.add(new Anchor(hrefText, href));
 				} else {
-					href = s;
-					hrefText = s;
+					textEl.setText(textEl.getText() + s + " ");
 				}
-				descriptionSpan.add(new Anchor(hrefText, href));
-			} else {
-				textEl.setText(textEl.getText() + s + " ");
 			}
 		}
 
@@ -327,23 +329,31 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 		Column nameColumn = new Column(ColumnSize.SM_3, ColumnSize.XS_3);
 		nameColumn.addStyleName(PerunProfileResources.INSTANCE.gss().personalInfoLabel());
 		String urn = personalAttribute.getUrn();
+		String name;
 
-		// check if translated name is available
-		String translatedName = attributeNamesTranslations.get(urn);
-		if (translatedName == null) {
-			if (defaultName != null) {
-				translatedName = defaultName;
-			} else {
-				// parse name from urn
-				String[] split = urn.split(":");
-				if (split.length < 1) {
-					return nameColumn;
+		// check if there is name from configuration for current locale
+		String configName = personalAttribute.getLocalizedName(Utils.getLocale());
+		if (configName != null) {
+			name = configName;
+		} else {
+			// check if translated name is available
+			String translatedName = attributeNamesTranslations.get(urn);
+			if (translatedName == null) {
+				if (defaultName != null) {
+					translatedName = defaultName;
+				} else {
+					// parse name from urn
+					String[] split = urn.split(":");
+					if (split.length == 1) {
+						translatedName = split[split.length - 1];
+					}
 				}
-				translatedName = split[split.length - 1];
 			}
+
+			name = translatedName;
 		}
 
-		Text nameText = new Text(translatedName);
+		Text nameText = new Text(name);
 
 		nameColumn.add(nameText);
 


### PR DESCRIPTION
* Now it is possible to define for each attribute name that will be
displayed in config file.

* Now the syntax for defining attribute that should be displayed looks
like this:
[EnName|CzName]urn[EnDescription|CzDescription]

* The only required parameter is the urn.

* If there is only one name or language specified, it will be used as a
en version. In other words, you can not define only Czech version. You
can define EN and CZ or EN or none.

* Created enum Locale to represent current page local.