### PR TITLE
WUI: Refresh group initial form

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/model/RegistrarObject.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/model/RegistrarObject.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.wui.registrar.model;
 
 import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.core.client.JsArray;
 import cz.metacentrum.perun.wui.client.utils.JsUtils;
 import cz.metacentrum.perun.wui.model.PerunException;
 import cz.metacentrum.perun.wui.model.beans.*;
@@ -192,5 +193,44 @@ public class RegistrarObject extends JavaScriptObject {
 	public final ArrayList<Identity> getSimilarUsers() {
 		return JsUtils.jsoAsList(JsUtils.getNativePropertyArray(this, "similarUsers"));
 	}
+
+	/**
+	 * Set Group initial form content to the registrar object
+	 *
+	 * @param form form to be set
+	 */
+	public final void setGroupFormInitial(ArrayList<ApplicationFormItemData> form) {
+
+		JsArray<ApplicationFormItemData> arr = JavaScriptObject.createArray().cast();
+		if (form != null) {
+			for (ApplicationFormItemData d : form) {
+				arr.push(d);
+			}
+		}
+		if (arr.length() > 0) {
+			setGroupFormInitialInternal(arr);
+		} else {
+			setGroupFormInitialInternal(null);
+		}
+
+	}
+
+	/**
+	 * Set native JS array of ApplicationFormItems.
+	 *
+	 * @param data
+	 */
+	private final native void setGroupFormInitialInternal(JsArray<ApplicationFormItemData> data) /*-{
+		this.groupFormInitial = data;
+	}-*/;
+
+	/**
+	 * Set group initial form exception
+	 *
+	 * @param ex Group initial form exception
+	 */
+	public final native PerunException setGroupFormInitialException(PerunException ex) /*-{
+		this.groupFormInitialException = ex;
+	}-*/;
 
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
@@ -150,12 +150,12 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 				ArrayList<Attribute> attrList = registrar.getVoAttributes();
 				for (Attribute a : attrList) {
 					if (a.getFriendlyName().equals("voLogoURL")) {
-						logo.setUrl(a.getValue());
-						logo.setVisible(true);
+						if (a.getValue() != null) {
+							logo.setUrl(a.getValue());
+							logo.setVisible(true);
+						}
 					}
 				}
-
-
 
 				if (registrar.getException() != null) {
 					if (registrar.getException().getName().equals("VoNotExistsException") ||

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/FormStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/FormStep.java
@@ -36,6 +36,14 @@ public abstract class FormStep implements Step {
 		return result;
 	}
 
+	public RegistrarObject getRegistrar() {
+		return registrar;
+	}
+
+	public PerunForm getForm() {
+		return form;
+	}
+
 	protected String getUnknownMail() {
 		for (PerunFormItem item : form.getPerunFormItems()) {
 			if (item instanceof ValidatedEmail) {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/FormStepManager.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/FormStepManager.java
@@ -13,6 +13,8 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 /**
+ * Handles users going through all steps of registration.
+ *
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
  */
 public class FormStepManager implements StepManager {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/GroupInitStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/GroupInitStep.java
@@ -1,6 +1,10 @@
 package cz.metacentrum.perun.wui.registrar.pages.steps;
 
+import com.google.gwt.core.client.JavaScriptObject;
 import cz.metacentrum.perun.wui.json.Events;
+import cz.metacentrum.perun.wui.json.JsonEvents;
+import cz.metacentrum.perun.wui.json.managers.AuthzManager;
+import cz.metacentrum.perun.wui.json.managers.RegistrarManager;
 import cz.metacentrum.perun.wui.model.PerunException;
 import cz.metacentrum.perun.wui.model.beans.Application;
 import cz.metacentrum.perun.wui.model.common.PerunPrincipal;
@@ -14,6 +18,8 @@ import cz.metacentrum.perun.wui.registrar.widgets.PerunForm;
  */
 public class GroupInitStep extends FormStep {
 
+	PerunPrincipal localPP;
+
 	public GroupInitStep(RegistrarObject registrar, PerunForm form) {
 		super(registrar, form);
 		this.result = new Result(Type.GROUP_INIT, registrar.getGroup(), registrar.hasGroupFormAutoApproval());
@@ -23,6 +29,46 @@ public class GroupInitStep extends FormStep {
 	public void call(final PerunPrincipal pp, Summary summary, final Events<Result> events) {
 
 		events.onLoadingStart();
+		this.localPP = pp;
+
+		// if there is a VoInitForm then there should be previous step where user submitted VO init application
+		// it it`s in an auto-approval mode, then User might have been created and we want to reflect this in
+		// group application, hence we will forcefully reload its form and session info.
+		if (!registrar.getVoFormInitial().isEmpty() &&
+				registrar.getVoFormInitialException() == null &&
+				registrar.hasVoFormAutoApproval()) {
+
+			reloadGroupAppData(new JsonEvents() {
+				@Override
+				public void onFinished(JavaScriptObject result) {
+					// continue after all is loaded
+					continueWithForm(events);
+				}
+
+				@Override
+				public void onError(PerunException error) {
+
+				}
+
+				@Override
+				public void onLoadingStart() {
+
+				}
+			});
+		} else {
+			// no group reloading
+			continueWithForm(events);
+		}
+
+	}
+
+	/**
+	 * Finish form processing (previously part of call() method).
+	 * Called after group form is refreshed.
+	 *
+	 * @param events events of original call to continue with
+	 */
+	private void continueWithForm(final Events<Result> events) {
 
 		if (registrar.getGroupFormInitialException() != null) {
 			result.setException(registrar.getGroupFormInitialException());
@@ -40,11 +86,60 @@ public class GroupInitStep extends FormStep {
 		}
 
 		form.setApp(Application.createNew(registrar.getVo(), registrar.getGroup(), Application.ApplicationType.INITIAL,
-				getFedInfo(pp), pp.getActor(), pp.getExtSource(), pp.getExtSourceType(), pp.getExtSourceLoa(), pp.getUser()));
+				getFedInfo(localPP), localPP.getActor(), localPP.getExtSource(), localPP.getExtSourceType(), localPP.getExtSourceLoa(), localPP.getUser()));
 
 		form.setOnSubmitEvent(getOnSubmitEvent(events));
 
 		form.performAutoSubmit();
+
+	}
+
+	/**
+	 * In some cases we want to reload form data
+	 */
+	private void reloadGroupAppData(JsonEvents events) {
+
+		AuthzManager.getPerunPrincipal(new JsonEvents() {
+			@Override
+			public void onFinished(JavaScriptObject result) {
+				localPP = result.cast();
+
+				// since this is a group initi form we know that vo and group are not null.
+				RegistrarManager.initializeRegistrar(registrar.getVo().getShortName(), registrar.getGroup().getName(), new JsonEvents() {
+					@Override
+					public void onFinished(JavaScriptObject result) {
+						RegistrarObject ro = result.cast();
+						registrar.setGroupFormInitial(ro.getGroupFormInitial());
+						registrar.setGroupFormInitialException(ro.getGroupFormInitialException());
+						// continue with the step
+						events.onFinished(null);
+					}
+
+					@Override
+					public void onError(PerunException error) {
+						// ignore and continue with the step
+						events.onFinished(null);
+					}
+
+					@Override
+					public void onLoadingStart() {
+					}
+				});
+
+			}
+
+			@Override
+			public void onError(PerunException error) {
+				// ignore it and continue with default form init processing
+				events.onFinished(null);
+			}
+
+			@Override
+			public void onLoadingStart() {
+			}
+		});
+
+
 	}
 
 }


### PR DESCRIPTION
- When anonymous person submits vo registration with automatic
  approval, user is created in Perun. When he continues with
  registration to group, this information is not reflected on the form,
  since it was loaded before.
- Now we reload group form during the process, hence form items can be
  pre-filled with data from Perun (submitted vo form) and group form
  is submitted with user id set.
- Fixed displaying vo logo.
- Added methods to set back form and exception into registrar object.