### PR TITLE
WUI: Fallback to english on registration form

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
@@ -748,10 +748,10 @@ public final class PerunConfiguration {
 	/**
 	 * Parse name values from given value and returns the rest of the String.
 	 * E.g.: if '[EnName,CzName]urn:perun:user:attribute-def:def:organization[EnDescription|CzDescription]'
-	 * is given, then EnName and CzName are parsed and 
+	 * is given, then EnName and CzName are parsed and
 	 * 'urn:perun:user:attribute-def:def:organization[EnDescription|CzDescription]'
 	 * is returned.
-	 * 
+	 *
 	 * @param value String starting with [EnName{|CzName}] where the cz name is optional.
 	 * @param attribute personal attribute where the data are being stored.
 	 * @return rest of the string without name part
@@ -765,7 +765,7 @@ public final class PerunConfiguration {
 				.replaceFirst("\\[", "")
 				.replaceFirst("]", "")
 				.split("\\|");
-		
+
 		String enName = split[0];
 		attribute.addName(Locale.EN, enName);
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItem.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItem.java
@@ -113,6 +113,12 @@ public abstract class PerunFormItem extends FormGroup {
 					return getItemData().getFormItem().getItemTexts(getLang()).getLabel();
 				}
 			}
+			if (getItemData().getFormItem().getItemTexts("en") != null) {
+				if ((getItemData().getFormItem().getItemTexts("en").getLabel() != null)
+						&& (!getItemData().getFormItem().getItemTexts("en").getLabel().isEmpty())) {
+					return getItemData().getFormItem().getItemTexts("en").getLabel();
+				}
+			}
 			if ((getItemData().getFormItem().getShortname() != null)
 					&& (!getItemData().getFormItem().getShortname().isEmpty())) {
 				return getItemData().getFormItem().getShortname();

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
@@ -89,6 +89,10 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 			setValue(getItemData().getPrefilledValue());
 
 			String helpText = getItemData().getFormItem().getItemTexts(getLang()).getHelp();
+			if (helpText == null) {
+				// fallback to english
+				helpText = getItemData().getFormItem().getItemTexts("en").getHelp();
+			}
 			if (helpText != null) {
 				help.setHTML(SafeHtmlUtils.fromString(helpText).asString());
 			}
@@ -223,6 +227,9 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 	public Map<String, String> parseItemOptions(){
 
 		String options = getItemData().getFormItem().getItemTexts(getLang()).getOptions();
+		if (options == null || options.isEmpty()) {
+			options = getItemData().getFormItem().getItemTexts("en").getOptions();
+		}
 
 		Map<String, String> map = new HashMap<String, String>();
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/validators/PerunFormItemValidatorImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/validators/PerunFormItemValidatorImpl.java
@@ -36,6 +36,9 @@ public abstract class PerunFormItemValidatorImpl<T extends PerunFormItem> implem
 
 	public String getErrorMsgOrDefault(T item) {
 		String errorText = item.getItemData().getFormItem().getItemTexts(item.getLang()).getErrorText();
+		if (errorText == null || errorText.isEmpty()) {
+			errorText = item.getItemData().getFormItem().getItemTexts("en").getErrorText();
+		}
 
 		if (errorText == null || errorText.isEmpty()) {
 			return translation.incorrectFormat();


### PR DESCRIPTION
- If form item doesn't have properties for specific locale, it showed
  wrong form (fallback to labels, empty help or error messages).
- Now for cases when localized property is null or empty we fallback
  to "en" lang and return it instead.
- If its still null or empty, we fallback to previous solutions.

- This helps instances with a single language, since if user accessed
  them with locale supported by our GUI, it draw wrong form.
  Now it falls back to English.