### PR TITLE
WUI: Show entityId and eppn from UES attributes for foreign proxies

### DIFF
--- a/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/pages/JoinPage.java
+++ b/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/pages/JoinPage.java
@@ -192,6 +192,11 @@ public class JoinPage {
 				String translatedExtSourceName = PerunSession.getInstance().getPerunPrincipal().getExtSource();
 				String translatedActor = PerunSession.getInstance().getPerunPrincipal().getActor();
 
+				// check if identity is sourced from foreign proxy
+				String aa = PerunSession.getInstance().getPerunPrincipal().getAdditionInformation("authenticating-authority");
+				boolean foreignProxy = (aa != null && !aa.isEmpty());
+				String foreignEppn = "";
+
 				if (extSourceType.equals(ExtSource.ExtSourceType.IDP.getType())) {
 
 					translatedExtSourceName = translatedActor.split("@")[1];// Utils.translateIdp(translatedExtSourceName);
@@ -203,6 +208,17 @@ public class JoinPage {
 					}
 
 					translatedActor = translatedActor.split("@")[0];
+
+					if (foreignProxy) {
+						// get source identity EPPN value
+						String eppn = PerunSession.getInstance().getPerunPrincipal().getAdditionInformation("eppn");
+						if (eppn != null && !eppn.isEmpty()) {
+							translatedActor = eppn.split("@")[0];
+							foreignEppn = eppn;
+						}
+						// get source identity EntityId
+						translatedExtSourceName = Utils.translateIdp(aa);
+					}
 
 					// get actor from attributes if present
 					String displayName = PerunSession.getInstance().getPerunPrincipal().getAdditionInformation("displayName");
@@ -226,7 +242,7 @@ public class JoinPage {
 				heading.setVisible(true);
 				if (PerunSession.getInstance().getUser() != null) {
 					login.setText(PerunSession.getInstance().getUser().getFullName());
-					login.setSubText("( " + PerunSession.getInstance().getPerunPrincipal().getActor() + " )");
+					login.setSubText("( " + ((foreignProxy) ? foreignEppn : PerunSession.getInstance().getPerunPrincipal().getActor()) + " )");
 				} else {
 					login.setText(translatedActor);
 				}

--- a/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/pages/SelectPage.java
+++ b/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/pages/SelectPage.java
@@ -85,6 +85,11 @@ public class SelectPage {
 					String translatedExtSourceName = PerunSession.getInstance().getPerunPrincipal().getExtSource();
 					String translatedActor = PerunSession.getInstance().getPerunPrincipal().getActor();
 
+					// check if identity is sourced from foreign proxy
+					String aa = PerunSession.getInstance().getPerunPrincipal().getAdditionInformation("authenticating-authority");
+					boolean foreignProxy = (aa != null && !aa.isEmpty());
+					String foreignEppn = "";
+
 					if (extSourceType.equals(ExtSource.ExtSourceType.IDP.getType())) {
 
 						translatedExtSourceName = translatedActor.split("@")[1];// Utils.translateIdp(translatedExtSourceName);
@@ -95,6 +100,17 @@ public class SelectPage {
 						}
 
 						translatedActor = translatedActor.split("@")[0];
+
+						if (foreignProxy) {
+							// get source identity EPPN value
+							String eppn = PerunSession.getInstance().getPerunPrincipal().getAdditionInformation("eppn");
+							if (eppn != null && !eppn.isEmpty()) {
+								translatedActor = eppn.split("@")[0];
+								foreignEppn = eppn;
+							}
+							// get source identity EntityId
+							translatedExtSourceName = Utils.translateIdp(aa);
+						}
 
 						// get actor from attributes if present
 						String displayName = PerunSession.getInstance().getPerunPrincipal().getAdditionInformation("displayName");
@@ -118,7 +134,7 @@ public class SelectPage {
 					heading.setVisible(true);
 					if (PerunSession.getInstance().getUser() != null) {
 						login.setText(PerunSession.getInstance().getUser().getFullName());
-						login.setSubText("( " + PerunSession.getInstance().getPerunPrincipal().getActor() + " )");
+						login.setSubText("( " + ((foreignProxy) ? foreignEppn : PerunSession.getInstance().getPerunPrincipal().getActor()) + " )");
 					} else {
 						login.setText(translatedActor);
 					}

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/json/managers/AttributesManager.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/json/managers/AttributesManager.java
@@ -104,6 +104,20 @@ public class AttributesManager {
 	}
 
 	/**
+	 * Returns all non-empty UserExtSource attributes for selected UserExtSource.
+	 *
+	 * @param uesId UserExtSource id
+	 * @param events events done on callback
+	 * @return Request unique request
+	 */
+	public static Request getUesAttributes(int uesId, JsonEvents events) {
+
+		JsonClient client = new JsonClient(events);
+		if (uesId > 0) client.put("userExtSource", uesId);
+		return client.call(ATTRIBUTES_MANAGER + "getAttributes");
+	}
+
+	/**
 	 * Returns an Attribute by its name. Returns only non-empty attributes.
 	 *
 	 * @param vo Vo id

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/model/beans/RichUserExtSource.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/model/beans/RichUserExtSource.java
@@ -1,40 +1,65 @@
 package cz.metacentrum.perun.wui.profile.model.beans;
 
-import cz.metacentrum.perun.wui.client.utils.JsUtils;
 import cz.metacentrum.perun.wui.model.beans.Attribute;
 import cz.metacentrum.perun.wui.model.beans.UserExtSource;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
 /**
- * Extended UserExtSource entity containing the original ues and its email Attribute.
+ * Extended UserExtSource entity containing the original ues and its attributes
  *
  * @author Vojtech Sassmann &lt;vojtech.sassmann@gmail.com&gt;
  */
-public class RichUserExtSource extends UserExtSource {
+public class RichUserExtSource {
 
-	protected RichUserExtSource() {}
+	UserExtSource ues;
+	Map<String,Attribute> attributes = new HashMap<>();
 
-	/**
-	 * Get User's email
-	 *
-	 * @return User's email
-	 */
-	public final String getEmail() {
-		return JsUtils.getNativePropertyString(this, "email");
+	public RichUserExtSource(UserExtSource ues) {
+		this.ues = ues;
+	}
+
+	public RichUserExtSource(UserExtSource ues, ArrayList<Attribute> attrs) {
+		this(ues);
+		setAttributes(attrs);
+	}
+
+	public UserExtSource getUes() {
+		return ues;
+	}
+
+	public void setUes(UserExtSource ues) {
+		this.ues = ues;
 	}
 
 	/**
-	 * Set User's email in concrete ExtSource
+	 * Set attributes to RichUserExtSource object.
 	 *
-	 * @param email User's email
+	 * If attribute present, update it's value
+	 * If attribute not present, add to attr list
+	 *
+	 * @param attributes to set to RichUserExtSource object
 	 */
-	public final native void setEmail(String email) /*-{
-        this.email = email;
-    }-*/;
-
-	public static RichUserExtSource mapUes(UserExtSource ues, Attribute mailAttribute) {
-		RichUserExtSource richUserExtSource = (RichUserExtSource) ues;
-		richUserExtSource.setEmail(mailAttribute.getValue());
-
-		return richUserExtSource;
+	public final void setAttributes(ArrayList<Attribute> attributes) {
+		if (attributes != null) {
+			for (Attribute a : attributes) {
+				if (a != null) {
+					this.attributes.put(a.getURN(), a);
+				}
+			}
+		}
 	}
+
+	/**
+	 * Get specified user ext source attribute stored in rich user ext source
+	 *
+	 * @param urn URN of attribute to get
+	 * @return user ext source attribute or null if not present
+	 */
+	public final Attribute getAttribute(String urn) {
+		return this.attributes.get(urn);
+	}
+
 }

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/identities/IdentitiesUiHandlers.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/identities/IdentitiesUiHandlers.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.wui.profile.pages.identities;
 
 import com.gwtplatform.mvp.client.UiHandlers;
 import cz.metacentrum.perun.wui.model.beans.UserExtSource;
+import cz.metacentrum.perun.wui.profile.model.beans.RichUserExtSource;
 
 /**
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
@@ -9,7 +10,7 @@ import cz.metacentrum.perun.wui.model.beans.UserExtSource;
 public interface IdentitiesUiHandlers extends UiHandlers {
 
     void loadUserExtSources();
-    void removeUserExtSource(UserExtSource userExtSource);
+    void removeUserExtSource(RichUserExtSource userExtSource);
     void addUserExtSource();
 
 }


### PR DESCRIPTION
- When identity is from foreign proxy (has ues authenticating-authority
  attribute), we fallback to displaying its value as entityId
  to be translated on user profile and consolidator.
  Same goes for login/actor property, where we fallback to eppn
  attribute.