### PR TITLE
WUI: Offer VO extension before empty group form

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
@@ -238,19 +238,33 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 			} else if (voExtensionFormExists(registrar)) {
 
 				if (isMemberOfGroup(registrar) && groupExtensionFormExists(registrar)) {
+
+					for (ApplicationFormItemData item : registrar.getVoFormExtension()) {
+						if (!item.getFormItem().getType().equals(ApplicationFormItem.ApplicationFormItemType.HTML_COMMENT) &&
+								!item.getFormItem().getType().equals(ApplicationFormItem.ApplicationFormItemType.HEADING)) {
+							// offer only when VO doesn't have empty or "You are registered" form.
+							stepManager.addStep(new VoExtOfferStep(registrar, form)); // will offer only if form is valid
+							break;
+						}
+					}
+
 					// only members with correct extension form can extend
 					stepManager.addStep(new GroupExtStep(registrar, form));
+
 				} else {
+
 					stepManager.addStep(new GroupInitStep(registrar, form));
-				}
-				for (ApplicationFormItemData item : registrar.getVoFormExtension()) {
-					if (!item.getFormItem().getType().equals(ApplicationFormItem.ApplicationFormItemType.HTML_COMMENT) &&
-							!item.getFormItem().getType().equals(ApplicationFormItem.ApplicationFormItemType.HEADING)) {
-						// offer only when VO doesn't have empty or "You are registered" form.
-						stepManager.addStep(new VoExtOfferStep(registrar, form)); // will offer only if form is valid
-						break;
+
+					for (ApplicationFormItemData item : registrar.getVoFormExtension()) {
+						if (!item.getFormItem().getType().equals(ApplicationFormItem.ApplicationFormItemType.HTML_COMMENT) &&
+								!item.getFormItem().getType().equals(ApplicationFormItem.ApplicationFormItemType.HEADING)) {
+							// offer only when VO doesn't have empty or "You are registered" form.
+							stepManager.addStep(new VoExtOfferStep(registrar, form)); // will offer only if form is valid
+							break;
+						}
 					}
 				}
+
 				stepManager.addStep(new SummaryStep(formView));
 				stepManager.begin();
 


### PR DESCRIPTION
- We offered VO extension after initial group application was submitted.
  Since we now support group extension too, we must cover the case, when
  group extension is empty (extension is disabled for such group).
  In such case user ends up with an empty message without ability to
  continue. Hence we offer VO extension before group extension form.