### PR TITLE
WUI: Better ux for continue button and error messages

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/GeneralObject.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/GeneralObject.java
@@ -109,17 +109,6 @@ public class GeneralObject extends JavaScriptObject {
                 if (result.length > 0) return result;
                 return null;
 
-            } else if (this.beanName === "ExecService") {
-
-                var service = @cz.metacentrum.perun.wui.client.utils.JsUtils::getNativePropertyObject(Lcom/google/gwt/core/client/JavaScriptObject;Ljava/lang/String;)(this, "service");
-	            if (service !== null) {
-                    var serviceName = @cz.metacentrum.perun.wui.client.utils.JsUtils::getNativePropertyString(Lcom/google/gwt/core/client/JavaScriptObject;Ljava/lang/String;)(service, "name");
-                    var execType = @cz.metacentrum.perun.wui.client.utils.JsUtils::getNativePropertyString(Lcom/google/gwt/core/client/JavaScriptObject;Ljava/lang/String;)(this, "execServiceType");
-		            return serviceName + "("+execType+")";
-                } else {
-		            return null;
-	            }
-
             } else if (this.beanName === "AttributeDefinition") {
 
                 return @cz.metacentrum.perun.wui.client.utils.JsUtils::getNativePropertyString(Lcom/google/gwt/core/client/JavaScriptObject;Ljava/lang/String;)(this, "displayName");

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolverImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolverImpl.java
@@ -215,14 +215,14 @@ public class ExceptionResolverImpl implements ExceptionResolver {
 		this.isSoft = isSoft;
 	}
 	private String getBeanName() {
-		if (bean == null) {
-			return "unknown";
+		if (bean != null) {
+			if (bean instanceof Vo) {
+				return bean.getName();
+			} else if (bean instanceof Group) {
+				return ((Group) bean).getShortName();
+			}
 		}
-		if (bean instanceof Group) {
-			return ((Group) bean).getShortName();
-		} else {
-			return bean.getName();
-		}
+		return "unknown";
 	}
 
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
@@ -247,7 +247,7 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("You have already submitted extension application to {0}")
 	public String alreadySubmittedExtension(String voName);
 
-	@DefaultMessage("You can check state of your application in <a href=\"{0}#submitted\">{1}</a>.")
+	@DefaultMessage("<br/>You can check state of your application in <a href=\"{0}#submitted\">{1}</a>.")
 	public String visitSubmitted(String url, String title);
 
 	@DefaultMessage("You are already registered")
@@ -262,13 +262,13 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("You can`t register to {0}")
 	public String cantBecomeMember(String voOrGroupName);
 
-	@DefaultMessage("The Identity Provider you used to log-in ({0}) doesn`t provide information about your Level of Assurance (LoA). Please ask your IDP to publish such information or use different IDP.")
+	@DefaultMessage("<br/>The Identity Provider you used to log-in ({0}) doesn`t provide information about your Level of Assurance (LoA). Please ask your IDP to publish such information or use different IDP.")
 	public String cantBecomeMemberLoa(String idpName);
 
-	@DefaultMessage("You don`t have required Level of Assurance (LoA) to display registration form. Contact your IDP ({0}) and prove your identity to him by official ID card (passport, driving license). If you have another identity with higher Level of Assurance, try to use it instead.")
+	@DefaultMessage("<br/>You don`t have required Level of Assurance (LoA) to display registration form. Contact your IDP ({0}) and prove your identity to him by official ID card (passport, driving license). If you have another identity with higher Level of Assurance, try to use it instead.")
 	public String cantBecomeMemberInsufficientLoa(String idpName);
 
-	@DefaultMessage("<h4>You can`t submit the registration</h4><p>The Identity Provider you used to log-in ({0}) doesn`t provide data required by the registration form. Please ask your IDP to publish following attributes or use different IDP.")
+	@DefaultMessage("<h4>You can`t submit the registration</h4><p><br/>The Identity Provider you used to log-in ({0}) doesn`t provide data required by the registration form. Please ask your IDP to publish following attributes or use different IDP.")
 	public String missingRequiredData(String idpName);
 
 	@DefaultMessage("Missing attribute: {0}")

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
@@ -30,6 +30,7 @@ import org.gwtbootstrap3.client.ui.ListGroupItem;
 import org.gwtbootstrap3.client.ui.Modal;
 import org.gwtbootstrap3.client.ui.ModalBody;
 import org.gwtbootstrap3.client.ui.ModalFooter;
+import org.gwtbootstrap3.client.ui.constants.ButtonSize;
 import org.gwtbootstrap3.client.ui.constants.ButtonType;
 import org.gwtbootstrap3.client.ui.constants.ColumnOffset;
 import org.gwtbootstrap3.client.ui.constants.ColumnSize;
@@ -721,6 +722,9 @@ public class SummaryStep implements Step {
 		if (Window.Location.getParameter(urlParameter) != null) {
 
 			PerunButton continueButton = PerunButton.getButton(PerunButtonType.CONTINUE);
+			// make button more visible to the users
+			continueButton.setSize(ButtonSize.LARGE);
+			continueButton.setType(ButtonType.SUCCESS);
 
 			continueButton.addClickHandler(new ClickHandler() {
 				@Override

--- a/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
+++ b/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
@@ -98,14 +98,14 @@ continueButton=Pokračovat
 alreadyRegistered=Již jste registrován(a) v {0}
 alreadySubmitted=Již máte podanou přihlášku do {0}
 alreadySubmittedExtension=Již máte podanou žádost o prodloužení členství v {0}
-visitSubmitted=Stav podané přihlášky můžete zkontrolovat v části <a href="{0}#submitted">{1}</a>.
+visitSubmitted=<br/>Stav podané přihlášky můžete zkontrolovat v části <a href="{0}#submitted">{1}</a>.
 cantExtendMembership=Již jste členem
 cantExtendMembershipOutside=<br/>Vaše členství v <i>{1}</i> je platné do <b>{0}</b>.
 cantExtendMembershipInsufficientLoa=Pro prodloužení členství nemáte dostatečně ověřenou identitu (LoA = Level of Assurance). Kontaktujte svého poskytovatele identity ({0}) a prokažte mu svoji identitu předložením oficiálního dokladu (občanský průkaz, pas). Pokud máte k dispozici jinou identitu s vyšším stupněm ověření, zkuste se přihlásit pomocí ní.
 cantBecomeMember=Nemůžete se registrovat do {0}
-cantBecomeMemberLoa=Poskytovatel Vaší identity, kterého jste použili při přihlášení ({0}) neposkytuje informaci o stupni Vašeho ověření (LoA = Level of Assurance). Prosím požádejte svého poskytovatele identity o zveřejěnní této informace nebo použijte jiného poskytovatele identity.
-cantBecomeMemberInsufficientLoa=Pro zobrazení registračního formuláře nemáte dostatečně ověřenou identitu (LoA = Level of Assurance). Kontaktujte svého poskytovatele identity ({0}) a prokažte mu svoji identitu předložením oficiálního dokladu (občanský průkaz, pas). Pokud máte k dispozici jinou identitu s vyšším stupněm ověření, zkuste se přihlásit pomocí ní.
-missingRequiredData=<h4>Nemůžete se registrovat</h4><p>Poskytovatel Vaší identity, kterého jste použili při přihlášení ({0}) neposkytuje ověřená data vyžadovaná registračním formulářem. Prosím požádejte svého poskytovatele identity, aby zveřejnil následující atributy nebo použijte jiného poskytovatele identity.
+cantBecomeMemberLoa=<br/>Poskytovatel Vaší identity, kterého jste použili při přihlášení ({0}) neposkytuje informaci o stupni Vašeho ověření (LoA = Level of Assurance). Prosím požádejte svého poskytovatele identity o zveřejěnní této informace nebo použijte jiného poskytovatele identity.
+cantBecomeMemberInsufficientLoa=<br/>Pro zobrazení registračního formuláře nemáte dostatečně ověřenou identitu (LoA = Level of Assurance). Kontaktujte svého poskytovatele identity ({0}) a prokažte mu svoji identitu předložením oficiálního dokladu (občanský průkaz, pas). Pokud máte k dispozici jinou identitu s vyšším stupněm ověření, zkuste se přihlásit pomocí ní.
+missingRequiredData=<h4>Nemůžete se registrovat</h4><p><br/>Poskytovatel Vaší identity, kterého jste použili při přihlášení ({0}) neposkytuje ověřená data vyžadovaná registračním formulářem. Prosím požádejte svého poskytovatele identity, aby zveřejnil následující atributy nebo použijte jiného poskytovatele identity.
 missingAttribute=Chybějící atribut: {0}
 voNotExistsException=Organizace / projekt s názvem <i>{0}</i> neexistuje. Zkontrolujte si prosím správnost odkazu v adresním řádku prohlížeče.
 groupNotExistsException=Skupina s názvem <i>{0}</i> neexistuje. Zkontrolujte si prosím správnost odkazu v adresním řádku prohlížeče.


### PR DESCRIPTION
- Add newline to error/warning texts displayed on registration
  form (including translation).
- Make "continue >" button more visible by using SUCCESS and
  LARGE button style.
- Removed unused code from GeneralObject.