### PR TITLE
WUI: Leave form for vo extension if user is a member

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
@@ -305,7 +305,17 @@ public class SummaryStep implements Step {
 			continueBtn = getContinueButton(TARGET_EXISTING);
 		}
 
+		// FIXME: HACK for ELIXIR - if is member and link should go out of registrar, leave immediatelly
+		if (summary.alreadyMemberOfVo()) {
+			String url = Window.Location.getParameter(TARGET_EXISTING);
+			if (url != null && !url.isEmpty()) {
+				Window.Location.assign(url);
+			}
+		}
+
+		// for others display summary
 		displaySummary(title, messages, continueBtn);
+
 	}
 
 	/**


### PR DESCRIPTION
- Do not wait for continue button in case of vo extension
  if user is a member and targetexisting url param is defined.