### PR TITLE
WUI: Handle generated logins

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItemData.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItemData.java
@@ -133,6 +133,22 @@ public class ApplicationFormItemData extends JavaScriptObject {
 	}-*/;
 
 	/**
+	 * Is generated
+	 * @return TRUE if pre-filled value was generated
+	 */
+	public final native boolean isGenerated() /*-{
+		if(typeof this.generated == "undefined") return false;
+		return this.generated;
+	}-*/;
+
+	/**
+	 * Set generated
+	 */
+	public final native void setGenerated(boolean generated) /*-{
+		this.generated = generated;
+	}-*/;
+
+	/**
 	 * Returns Perun specific type of object
 	 *
 	 * @return type of object

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
@@ -468,6 +468,12 @@ public class PerunForm extends FieldSet {
 			// cast form item back
 			ApplicationFormItem formItem = formItemJSON.getJavaScriptObject().cast();
 
+			// clear pre-filled value if login was generated, since we want server to register new login
+			if (ApplicationFormItem.ApplicationFormItemType.USERNAME.equals(formItem.getType()) &&
+					item.getItemData().isGenerated()) {
+				prefilled = "";
+			}
+
 			// prepare package with data
 			ApplicationFormItemData itemData = ApplicationFormItemData.construct(formItem, formItem.getShortname(), value, prefilled, item.getItemData().getAssuranceLevel() != null ? item.getItemData().getAssuranceLevel() : "");
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
@@ -81,7 +81,7 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 				return new TextArea(data, lang, onlyPreview);
 			case USERNAME:
 				Username username = new Username(data, lang, onlyPreview);
-				if (data.getPrefilledValue() != null && !data.getPrefilledValue().isEmpty()) {
+				if (data.getPrefilledValue() != null && !data.getPrefilledValue().isEmpty() && !data.isGenerated()) {
 					username.setEnable(false);
 				}
 				return username;


### PR DESCRIPTION
- Pre-filled value in USERNAME type of application form can be marked
  as generated. It is then considered as editable and on form submission
  pre-filled value is cleared to make sure, new login is registered and
  not considered as "already existing".