### PR TITLE
Add forceAuthn for identity consolidation workflow

### DIFF
--- a/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/widgets/Wayf.java
+++ b/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/widgets/Wayf.java
@@ -128,7 +128,7 @@ public class Wayf extends Composite {
 							authnContextClassRef += "%20urn:cesnet:proxyidp:filter:"+group.getFilter();
 						}
 
-						final String redirectUrl = PerunConfiguration.getWayfSpLogoutUrl() + "?return=" + PerunConfiguration.getWayfSpLoginUrl() + URL.encodeQueryString("?authnContextClassRef=" + authnContextClassRef +"&target="+consolidatorUrl);
+						final String redirectUrl = PerunConfiguration.getWayfSpLogoutUrl() + "?return=" + PerunConfiguration.getWayfSpLoginUrl() + URL.encodeQueryString("?authnContextClassRef=" + authnContextClassRef +"&target="+consolidatorUrl + "&forceAuthn=true");
 						Window.Location.assign(redirectUrl);
 					}
 				});

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
@@ -531,7 +531,7 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 										// FINAL URL must logout from SP, login to SP using specified IdP, redirect to IC and after that return to application form
 										String token = ((BasicOverlayObject) jso).getString();
 										String consolidatorUrl = Utils.getIdentityConsolidatorLink("fed", true) + URL.encodeQueryString("&token=" + token);
-										String redirectUrl = PerunConfiguration.getWayfSpLogoutUrl() + "?return=" + PerunConfiguration.getWayfSpLoginUrl() + URL.encodeQueryString("?authnContextClassRef=urn:cesnet:proxyidp:template:cesnet%20urn:cesnet:proxyidp:idpentityid:" + finalEntityId + "&target=" + consolidatorUrl);
+										String redirectUrl = PerunConfiguration.getWayfSpLogoutUrl() + "?return=" + PerunConfiguration.getWayfSpLoginUrl() + URL.encodeQueryString("?authnContextClassRef=urn:cesnet:proxyidp:template:cesnet%20urn:cesnet:proxyidp:idpentityid:" + finalEntityId + "&target=" + consolidatorUrl + "&forceAuthn=true");
 										Window.Location.assign(redirectUrl);
 									}
 


### PR DESCRIPTION
When the identity consolidation workflow starts it necessary to send
forceAuth parameter to SP which will pass it to the proxy IdP.

If the forceAuth flag is not present, the SP have to be configured to
send logout to proxy and the proxy have to do the logout as well. Not
all proxies are supporting this, so for that using forceAuthn is
required.