### PR TITLE
WUI: Do not offer similar users dialog when user have pending applications

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
@@ -186,7 +186,7 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 					// CHECK SIMILAR USERS
 					// Make sure we load form only after user decide to skip identity joining
 
-					if (!registrar.getSimilarUsers().isEmpty()) {
+					if (!registrar.getSimilarUsers().isEmpty() && !isApplicationPending(registrar)) {
 						showSimilarUsersDialog(registrar.getSimilarUsers(), new ClickHandler() {
 							@Override
 							public void onClick(ClickEvent event) {
@@ -215,6 +215,19 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 			public void onLoadingStart() {
 				loader.onLoading(translation.preparingForm());
 			}
+
+			boolean isApplicationPending(RegistrarObject registrar) {
+				if (isPending(registrar.getVoFormInitialException())) return true;
+				if (isPending(registrar.getGroupFormInitialException())) return true;
+				if (isPending(registrar.getVoFormExtensionException())) return true;
+				if (isPending(registrar.getGroupFormExtensionException())) return true;
+				return false;
+			}
+
+			boolean isPending(PerunException ex) {
+				return (ex != null && "DuplicateRegistrationAttemptException".equals(ex.getName()));
+			}
+
 		});
 
 	}


### PR DESCRIPTION
- When user visits registration form again and his application is pending,
  then dialog for joining identities was displayed and stuck the user for 5s,
  just to later display the fact, that application is pending.
- Now we display notice about pending application from start.