### PR TITLE
WUI: Updates to translation, loa and duplicateRegistrationAttemptException

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/PerunException.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/PerunException.java
@@ -186,6 +186,18 @@ public class PerunException extends JavaScriptObject {
 		return o.getErrorId().equals(this.getErrorId());
 	}
 
+	public final Application getApplication() {
+		return JsUtils.getNativePropertyObject(this, "application").cast();
+	}
+
+	public final native void setApplication(Application application) /*-{
+		this.application = application;
+	}-*/;
+
+	public final ArrayList<ApplicationFormItemData> getApplicationData() {
+		return JsUtils.jsoAsList(JsUtils.getNativePropertyArray(this, "applicationData"));
+	}
+
 	public final Attribute getAttribute() {
 		return JsUtils.getNativePropertyObject(this, "attribute").cast();
 	}

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItemData.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItemData.java
@@ -125,6 +125,21 @@ public class ApplicationFormItemData extends JavaScriptObject {
 		return this.assuranceLevel;
 	}-*/;
 
+	public final int getAssuranceLevelAsInt() {
+
+		String value = getAssuranceLevel();
+		if (value == null) return 0;
+		if ("null".equals(value)) return 0;
+		if (value.isEmpty()) return 0;
+
+		try {
+			return Integer.parseInt(value);
+		} catch (NumberFormatException ex) {
+			return 0;
+		}
+
+	}
+
 	/**
 	 * Set assuranceLevel
 	 */

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolver.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolver.java
@@ -2,6 +2,7 @@ package cz.metacentrum.perun.wui.registrar.client;
 
 import cz.metacentrum.perun.wui.model.GeneralObject;
 import cz.metacentrum.perun.wui.model.PerunException;
+import cz.metacentrum.perun.wui.model.beans.Application;
 
 /**
  * Provides info about exception which can be shown to user.
@@ -59,4 +60,7 @@ public interface ExceptionResolver {
 	 * @return related bean to exception if any. Null otherwise.
      */
 	GeneralObject getBean();
+
+	Application getApplication();
+
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolverImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolverImpl.java
@@ -8,6 +8,7 @@ import cz.metacentrum.perun.wui.client.utils.JsUtils;
 import cz.metacentrum.perun.wui.client.utils.Utils;
 import cz.metacentrum.perun.wui.model.GeneralObject;
 import cz.metacentrum.perun.wui.model.PerunException;
+import cz.metacentrum.perun.wui.model.beans.Application;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemData;
 import cz.metacentrum.perun.wui.model.beans.Group;
 import cz.metacentrum.perun.wui.model.beans.Vo;
@@ -25,6 +26,7 @@ public class ExceptionResolverImpl implements ExceptionResolver {
 	private String text;
 	private String subtext;
 	private boolean isSoft;
+	private Application application;
 	private PerunRegistrarTranslation trans = GWT.create(PerunRegistrarTranslation.class);
 
 	public void resolve(PerunException exception, GeneralObject bean) {
@@ -65,6 +67,11 @@ public class ExceptionResolverImpl implements ExceptionResolver {
 	@Override
 	public GeneralObject getBean() {
 		return bean;
+	}
+
+	@Override
+	public Application getApplication() {
+		return application;
 	}
 
 	private void resolve() {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
@@ -250,7 +250,7 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("You have already submitted extension application to {0}")
 	public String alreadySubmittedExtension(String voName);
 
-	@DefaultMessage("<br/>You can check state of your application in <a href=\"{0}#submitted\">{1}</a>.")
+	@DefaultMessage("<p>You can check details of your application in <a href=\"{0}#submitted\">{1}</a>.")
 	public String visitSubmitted(String url, String title);
 
 	@DefaultMessage("You are already registered")
@@ -316,6 +316,17 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("In order to access CESNET services you must log-in using verified academic identity (at least once a year). Please use such identity to access this form.")
 	public String notEligibleCESNET();
 
+	@DefaultMessage("<p>Your application still awaits for mail address verification. If you continue now, it is most probable, that service will redirect you back to the registration form.<p>Please check your mailbox for verification mail. Once your application is verified and approved, you will be able to access the service.")
+	public String redirectWaitForVerification();
+
+	@DefaultMessage("<p>Your application still awaits administrators approval. If you continue now, it is most probable, that service will redirect you back to the registration form.<p>Once your application is approved by administrator, you will be notified and able to access the service.")
+	public String redirectWaitForApproval();
+
+	@DefaultMessage("I understand")
+	public String understand();
+
+	@DefaultMessage("Continue anyway")
+	public String continueAnyway();
 
 	/* ------------ LOADER MESSAGES ---------------- */
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.java
@@ -221,7 +221,7 @@ public class AppDetailView extends ViewImpl implements AppDetailPresenter.MyView
 				for (final ApplicationFormItemData item : list) {
 					if (item.getFormItem() != null &&
 							item.getFormItem().getType().equals(ApplicationFormItem.ApplicationFormItemType.VALIDATED_EMAIL) &&
-							!item.getAssuranceLevel().equals("1")) {
+							item.getAssuranceLevelAsInt() < 1) {
 						found = true;
 
 						String val = SafeHtmlUtils.fromString((item.getValue()!=null) ? item.getValue() : "").asString();

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryImpl.java
@@ -142,7 +142,8 @@ public class SummaryImpl implements Summary {
 		if (registrar.getVoFormExtensionException() == null) {
 			return false;
 		}
-		if (registrar.getVoFormExtensionException().getName().equals("DuplicateRegistrationAttemptException")) {
+		if (registrar.getVoFormExtensionException().getName().equals("DuplicateRegistrationAttemptException") ||
+				registrar.getVoFormExtensionException().getName().equals("DuplicateExtensionAttemptException")) {
 			return true;
 		} else {
 			return false;
@@ -154,7 +155,8 @@ public class SummaryImpl implements Summary {
 		if (registrar.getGroupFormExtensionException() == null) {
 			return false;
 		}
-		if (registrar.getGroupFormExtensionException().getName().equals("DuplicateRegistrationAttemptException")) {
+		if (registrar.getGroupFormExtensionException().getName().equals("DuplicateRegistrationAttemptException") ||
+				registrar.getGroupFormExtensionException().getName().equals("DuplicateExtensionAttemptException")) {
 			return true;
 		} else {
 			return false;

--- a/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
+++ b/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
@@ -82,7 +82,7 @@ type=Typ
 virtualOrganization=Virtuální organizace
 group=Skupina
 showDetail=Zobrazit
-mailVerificationText=Zkontrolujte si prosím doručenou poštu pro <b>{0}</b>. Pokud jste neobdrželi zprávu pro oveření mailové adresy, zkontrolujte si složku pro SPAM nebo použijte tlačítko pro opětovné odeslání.
+mailVerificationText=Zkontrolujte si prosím doručenou poštu pro <b>{0}</b>. Pokud jste neobdrželi zprávu pro ověření mailové adresy, zkontrolujte si složku pro SPAM nebo použijte tlačítko pro opětovné odeslání.
 reSendMailVerificationButton=Znovu odeslat zprávu na ověření mailové adresy
 mailVerificationRequestSent=Zpráva pro ověření mailu odeslána na <b>{0}</b>
 
@@ -99,7 +99,7 @@ continueButton=Pokračovat
 alreadyRegistered=Již jste registrován(a) v {0}
 alreadySubmitted=Již máte podanou přihlášku do {0}
 alreadySubmittedExtension=Již máte podanou žádost o prodloužení členství v {0}
-visitSubmitted=<br/>Stav podané přihlášky můžete zkontrolovat v části <a href="{0}#submitted">{1}</a>.
+visitSubmitted=<p>Detaily podané přihlášky můžete zkontrolovat v části <a href="{0}#submitted">{1}</a>.
 cantExtendMembership=Již jste členem
 cantExtendMembershipOutside=<br/>Vaše členství v <i>{1}</i> je platné do <b>{0}</b>.
 cantExtendMembershipInsufficientLoa=Pro prodloužení členství nemáte dostatečně ověřenou identitu (LoA = Level of Assurance). Kontaktujte svého poskytovatele identity ({0}) a prokažte mu svoji identitu předložením oficiálního dokladu (občanský průkaz, pas). Pokud máte k dispozici jinou identitu s vyšším stupněm ověření, zkuste se přihlásit pomocí ní.
@@ -121,6 +121,11 @@ unableToSubmit=Formulář nelze odeslat
 cantSubmitLoA=Nelze podat přihlášku
 notAcademicLoA=Podle informací poskytnutých od <i>{0}</i> <b>nejste aktivním členem akademické obce</b>. Odhlaste se a přihlaste se znovu pomocí svojí domácí instituce (Univerzity), které jste aktivním členem.
 notEligibleCESNET=Pro přístup ke službám CESNETu je potřeba používat ověřenou akademickou identitu (alespoň 1x za rok se s ní musíte přihlásit). Prosím použijte akademickou identitu pro přístup k tomuto formuláři.
+
+redirectWaitForVerification=<p>Vaše přihláška stále čeká na ověření zadané mailové adresy. Pokud budete nyní pokračovat dál na koncovou službu, je velmi pravděpodobné, že budete přesměrováni zpět na registraci.<p>Prosím zkontrolujte si Vaši poštovaní schránku na zprávu pro ověření mailové adresy.<p>Jakmile bude Vaše adresa ověřena a přihláška schválena, budete moci přistupovat na koncovou službu.
+redirectWaitForApproval=<p>Vaše přihláška stále čeká na schválení administrátorem. Pokud budete nyní pokračovat dál na koncovou službu, je velmi pravděpodobné, že budete přesměrováni zpět na registraci.<p>Jakmile bude Vaše přihláška schválena, dostanete upozornění na mail a budete moci přistupovat na koncovou službu.
+understand=Rozumím
+continueAnyway=Přesto pokračovat
 
 # // --------------- LOADER MESSAGES -------------------------------- //
 


### PR DESCRIPTION
- These are not conflicting changes, which are part of "registrarWorkflow"
  branch, which will be finished later. Purpose is to ease deployment
  of server side changes.
- DuplicateRegistrationAttemptException now contains whole Application
  object including ApplicationFormItemData.
- We can compare loa of application form item data as integer,
  and this fixes issue with loa < 1.
- Adds new translation for future use.
- Since we rename DuplicateRegistrationAttemptException as a hack,
  we must check renamed "DuplicateExtensionAttemptException" when resolving,
  whether user applied for vo/group extension.