### PR TITLE
Profile - hide admin ssh keys

### DIFF
--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/settings/sshkeys/SshKeysView.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/settings/sshkeys/SshKeysView.java
@@ -45,6 +45,7 @@ public class SshKeysView extends ViewWithUiHandlers<SshKeysUiHandlers> implement
 	@UiField Div newAdminKeyButtonDiv;
 	@UiField Button newKeyButton;
 	@UiField Div newKeyButtonDiv;
+	@UiField Div adminKeysDiv;
 
 	private Attribute sshKeysAttribute;
 	private Attribute adminSshKeysAttribute;
@@ -98,6 +99,7 @@ public class SshKeysView extends ViewWithUiHandlers<SshKeysUiHandlers> implement
 		adminSshKeysAttribute = attribute;
 		((PerunLoader) adminSshKeysTable.getEmptyTableWidget()).onEmpty();
 		adminSshKeysTable.setRowData(parseValues(attribute));
+		adminKeysDiv.setVisible(true);
 	}
 
 	@Override
@@ -107,7 +109,11 @@ public class SshKeysView extends ViewWithUiHandlers<SshKeysUiHandlers> implement
 
 	@Override
 	public void setAdminSshKeysError(PerunException error) {
-		((PerunLoader) sshKeysTable.getEmptyTableWidget()).onError(error, event -> getUiHandlers().loadAdminSshKeys());
+		if ("AttributeNotExistsException".equals(error.getName())) {
+			adminKeysDiv.setVisible(false);
+		} else {
+			((PerunLoader) adminSshKeysTable.getEmptyTableWidget()).onError(error, event -> getUiHandlers().loadAdminSshKeys());
+		}
 	}
 
 	@Override

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/settings/sshkeys/SshKeysView.ui.xml
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/settings/sshkeys/SshKeysView.ui.xml
@@ -39,11 +39,13 @@
 			<b:Button type="SUCCESS" icon="PLUS" text="{trans.newPublicKey}" marginTop="5" ui:field="newKeyButton"/>
 		</b.html:Div>
 
-		<b:Heading size="H3" text="{trans.adminSshKeysHeading}"/>
-		<b.html:Text text="{trans.adminSshKeysNote}"/>
-		<b.gwt:CellTable ui:field="adminSshKeysTable" condensed="true" bordered="true" striped="true" addStyleNames="{res.gss.sshKeysTable}" />
-		<b.html:Div ui:field="newAdminKeyButtonDiv">
-			<b:Button type="SUCCESS" icon="PLUS" text="{trans.newPublicAdminKey}" marginTop="5" ui:field="newAdminKeyButton"/>
+		<b.html:Div ui:field="adminKeysDiv" visible="false">
+			<b:Heading size="H3" text="{trans.adminSshKeysHeading}"/>
+			<b.html:Text text="{trans.adminSshKeysNote}"/>
+			<b.gwt:CellTable ui:field="adminSshKeysTable" condensed="true" bordered="true" striped="true" addStyleNames="{res.gss.sshKeysTable}" />
+			<b.html:Div ui:field="newAdminKeyButtonDiv">
+				<b:Button type="SUCCESS" icon="PLUS" text="{trans.newPublicAdminKey}" marginTop="5" ui:field="newAdminKeyButton"/>
+			</b.html:Div>
 		</b.html:Div>
 
 	</b.html:Div>


### PR DESCRIPTION
* If the attribute for admin ssh keys does not exist in Perun, the table
with admin ssh keys is hidden.