### PR TITLE
Changed default message for loginNotAvailable

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
@@ -133,7 +133,7 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("Checking...")
 	public String checkingLogin();
 
-	@DefaultMessage("Login <b>is not available!</b>")
+	@DefaultMessage("Login <b>is not available!</b> Please choose another.")
 	public String loginNotAvailable();
 
 	@DefaultMessage("Unable to check login availability!")


### PR DESCRIPTION
- Message which is shown in registrar when entering login which is
  already taken was edited. It was "Login <b>is not available!</b>"
  and now it is "Login <b>is not available!</b> Please choose another."