### PR TITLE
PROFILE: Support preferred email change on profile

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/json/managers/UsersManager.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/json/managers/UsersManager.java
@@ -1,6 +1,7 @@
 package cz.metacentrum.perun.wui.json.managers;
 
 import com.google.gwt.http.client.Request;
+import cz.metacentrum.perun.wui.client.resources.PerunSession;
 import cz.metacentrum.perun.wui.json.JsonClient;
 import cz.metacentrum.perun.wui.json.JsonEvents;
 
@@ -189,6 +190,7 @@ public class UsersManager {
 		if (userId > 0) client.put("user", userId);
 		client.put("email", email);
 		client.put("lang", lang);
+		client.put("linkPath","/"+PerunSession.getInstance().getRpcServer()+"/profile/");
 		return client.call(USERS_MANAGER + "requestPreferredEmailChange");
 
 	}
@@ -208,6 +210,26 @@ public class UsersManager {
 		JsonClient client = new JsonClient(events);
 		if (userId > 0) client.put("user", userId);
 		return client.call(USERS_MANAGER + "getPendingPreferredEmailChanges");
+
+	}
+
+	/**
+	 * Validates change of preferred email in Perun
+	 *
+	 * @param userId Users ID
+	 * @param i Param "i" retrieved from URL
+	 * @param m Param "m" retrieved from URL
+	 * @param events Events done on callback
+	 *
+	 * @return Request unique request
+	 */
+	public static Request validatePreferredEmailChange(int userId, String i, String m, JsonEvents events){
+
+		JsonClient client = new JsonClient(events);
+		if (userId > 0) client.put("u", userId);
+		if (i != null && !i.isEmpty()) client.put("i", i);
+		if (m != null && !m.isEmpty()) client.put("m", m);
+		return client.call(USERS_MANAGER + "validatePreferredEmailChange");
 
 	}
 

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation.java
@@ -406,4 +406,13 @@ public interface PerunProfileTranslation extends PerunTranslation {
 	@DefaultMessage("Password for SAMBA service has been changed.")
 	String sambaPasswordSetNotif();
 
+	@DefaultMessage("Verify preferred e-mail")
+	String verifyEmailChangeTitle();
+
+	@DefaultMessage("Verifying e-mail")
+	String verifyingEmailChange();
+
+	@DefaultMessage("E-mail address {0} was verified and set as your preferred e-mail.")
+	String verifyingEmailChangeDone(String email);
+
 }

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalUiHandlers.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalUiHandlers.java
@@ -14,4 +14,6 @@ public interface PersonalUiHandlers extends UiHandlers {
 
     void updateEmail(String email);
 
+    void verifyEmail();
+
 }

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
@@ -2,7 +2,10 @@ package cz.metacentrum.perun.wui.profile.pages.personal;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style;
+import com.google.gwt.event.dom.client.ClickEvent;
+import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONValue;
+import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.cellview.client.TextColumn;
@@ -98,6 +101,12 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 	Modal updateEmailModal;
 	@UiField
 	FormLabel updateEmailLabel;
+	@UiField
+	Modal verifyEmailModal;
+	@UiField
+	PerunLoader verifyEmailLoader;
+	@UiField
+	Button doneButton;
 
 	@Inject
 	public PersonalView(PersonalViewUiBinder binder) {
@@ -220,6 +229,34 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 			updateEmailFormGroup.setValidationState(ValidationState.NONE);
 			updateEmailHelpBlock.setVisible(false);
 		}
+	}
+
+	@Override
+	public void verifyEmailChangeStart() {
+		doneButton.setEnabled(false);
+		verifyEmailLoader.getWidget().getElement().getStyle().setMarginTop(0, Style.Unit.PX);
+		verifyEmailLoader.setEmptyMessage("");
+		verifyEmailModal.setTitle(translation.verifyEmailChangeTitle());
+		verifyEmailLoader.onLoading(translation.verifyingEmailChange());
+		verifyEmailModal.show();
+	}
+
+	@Override
+	public void verifyEmailChangeError(PerunException ex) {
+		doneButton.setEnabled(true);
+		verifyEmailLoader.onError(ex, new ClickHandler() {
+			@Override
+			public void onClick(ClickEvent clickEvent) {
+				getUiHandlers().verifyEmail();
+			}
+		});
+	}
+
+	@Override
+	public void verifyEmailChangeDone(String email) {
+		doneButton.setEnabled(true);
+		verifyEmailLoader.setEmptyMessage(translation.verifyingEmailChangeDone(SafeHtmlUtils.fromString(email).asString()));
+		verifyEmailLoader.onFinishedEmpty();
 	}
 
 	/**

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.ui.xml
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.ui.xml
@@ -50,6 +50,15 @@
 			</b:ModalBody>
 		</b:Modal>
 
+		<b:Modal title="Verify preferred e-mail" ui:field="verifyEmailModal" closable="true" fade="true" dataBackdrop="STATIC" dataKeyboard="true" b:id="verifyEmailModal">
+			<b:ModalBody>
+				<p:PerunLoader ui:field="verifyEmailLoader" />
+			</b:ModalBody>
+			<b:ModalFooter>
+				<b:Button ui:field="doneButton" enabled="false" type="PRIMARY" dataDismiss="MODAL" dataTarget="verifyEmailModal">OK</b:Button>
+			</b:ModalFooter>
+		</b:Modal>
+
 	</b.html:Div>
 
 </ui:UiBinder>

--- a/perun-wui-profile/src/main/resources/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation_cs.properties
+++ b/perun-wui-profile/src/main/resources/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation_cs.properties
@@ -133,3 +133,6 @@ sambaPasswordSet=Heslo pro službu SAMBA již <b>máte nastaveno</b>. Můžete j
 sambaPasswordNotSet=Heslo pro službu SAMBA ještě <b>nemáte nastaveno</b>. Můžete si je vytvořit pomocí formuláře níže.
 setSambaPassword=Nastavit heslo
 sambaPasswordSetNotif=Heslo pro službu SAMBA bylo změněno.
+verifyEmailChangeTitle=Ověření preferovaného e-mailu
+verifyingEmailChange=Probíhá ověření
+verifyingEmailChangeDone=E-mailová adresa {0} byla ověřena a nastavena jako Váš preferovaný e-mail.


### PR DESCRIPTION
- Send request to change preferred mail with /profile/
  path, so that mail verification is done on profile again.
- Support mail verification on profile/personal page.