### PR TITLE
Registrar - fix of null

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
@@ -856,7 +856,7 @@ public class SummaryStep implements Step {
 				}
 			};
 
-			if (redirectTo != null && !redirectTo.isEmpty()) {
+			if (redirectTo != null && !redirectTo.isEmpty() && previousResult != null) {
 
 				int applicationId;
 				if (previousResult.getApplication() != null) {


### PR DESCRIPTION
* When the user is already a member of a vo or a group, the previous
result is null and the application cannot be loaded. In this case, we
just want to skip the check of the application state.
* This old implementation caused errors for users who were already
members with the combination of targetExisting query parameter.