### PR TITLE
Optional similar users finding

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/resources/PerunConfiguration.java
@@ -707,6 +707,15 @@ public final class PerunConfiguration {
 	}
 
 	/**
+	 * Checks whether the functionality of finding similar users is disabled.
+	 *
+	 * @return true when the property registrar.findSimilarUsers.disabled is set to true. False otherwise.
+	 */
+	public static boolean findSimilarUsersDisabled() {
+		return getConfigPropertyBoolean("registrar.findSimilarUsers.disabled");
+	}
+
+	/**
 	 * Returns list of string identifiers (format "vo_short_name:group_name" or "vo_short_name") for which
 	 * result page of registration/extension is skipped. Redirect value is expected in URL user used to visit
 	 * registration form. Redirect is immediate (normally it would display continue button).

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
@@ -232,7 +232,9 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 					// CHECK SIMILAR USERS
 					// Make sure we load form only after user decide to skip identity joining
 
-					if (!registrar.getSimilarUsers().isEmpty() && !isApplicationPending(registrar)) {
+					if (!registrar.getSimilarUsers().isEmpty() &&
+						!isApplicationPending(registrar) &&
+						!PerunConfiguration.findSimilarUsersDisabled()) {
 						showSimilarUsersDialog(registrar.getSimilarUsers(), new ClickHandler() {
 							@Override
 							public void onClick(ClickEvent event) {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.Window;
+import cz.metacentrum.perun.wui.client.resources.PerunConfiguration;
 import cz.metacentrum.perun.wui.client.resources.PerunSession;
 import cz.metacentrum.perun.wui.client.resources.PerunTranslation;
 import cz.metacentrum.perun.wui.client.utils.JsUtils;
@@ -226,7 +227,7 @@ public class PerunForm extends FieldSet {
 
 				if (result) {
 
-					if (checkSimilarUsersAgain) {
+					if (checkSimilarUsersAgain && !PerunConfiguration.findSimilarUsersDisabled()) {
 
 						// validation ok - check similar users
 						RegistrarManager.checkForSimilarUsers(getFormItemData(), new JsonEvents() {


### PR DESCRIPTION
- Finding of similar users while submitting the registration was made
  optional. Now it will be not trigered when the property
  registrar.findSimilarUsers.disabled is set to true.