### PR TITLE
Registrar - redirect users to summary page bug fix

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/FormStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/FormStep.java
@@ -72,6 +72,7 @@ public abstract class FormStep implements Step {
 					result.setRegisteredMail(unknownMail);
 				}
 				result.setApplication(jso.cast());
+				result.setException(null);
 				events.onFinished(result);
 			}
 


### PR DESCRIPTION
* When users failed to submit the application for the first time, the
registrar allowed them to try again. But if they succeeded, they were
not redirected to the summary page and it seemed that the submission
failed again.
* Fixed by changing exception in the submission result to null, if the
submission was successful. This is used later on to check the result of
the submission.