### PR TITLE
REGISTRAR: Allow editing submitted form to users

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/json/managers/RegistrarManager.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/json/managers/RegistrarManager.java
@@ -345,4 +345,23 @@ public class RegistrarManager {
 
 	}
 
+	/**
+	 * Update form items data of existing submitted application.
+	 * This might trigger verification and approval of application!
+	 *
+	 * @param applicationId ID of application
+	 * @param formItems Form items to be updated
+	 * @param events Events done on callback
+	 *
+	 * @return Request unique request
+	 */
+	public static Request updateFormItemsData(int applicationId, List<ApplicationFormItemData> formItems, JsonEvents events) {
+
+		JsonClient client = new JsonClient(true, events);
+		if (applicationId > 0) client.put("appId", applicationId);
+		if (formItems != null) client.put("data", formItems);
+		return client.call(REGISTRAR_MANAGER + "updateFormItemsData");
+
+	}
+
 }

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItem.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItem.java
@@ -309,7 +309,7 @@ public class ApplicationFormItem extends JavaScriptObject {
 	}-*/;
 
 	private final native void setApplicationTypes(JavaScriptObject object)/*-{
-        this.applicationTypes = applicationTypes;
+        this.applicationTypes = object;
 	}-*/;
 
 	// TODO - item texts
@@ -330,6 +330,11 @@ public class ApplicationFormItem extends JavaScriptObject {
 	 */
 	public final native void setItemTexts(String locale, ApplicationFormItemTexts itemTexts) /*-{
 		this.i18n[locale] = itemTexts;
+	}-*/;
+
+	public final native String[] getItemTextLocales() /*-{
+		console.log(Object.keys(this.i18n));
+		return Object.keys(this.i18n);
 	}-*/;
 
 	/**

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItem.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItem.java
@@ -333,7 +333,6 @@ public class ApplicationFormItem extends JavaScriptObject {
 	}-*/;
 
 	public final native String[] getItemTextLocales() /*-{
-		console.log(Object.keys(this.i18n));
 		return Object.keys(this.i18n);
 	}-*/;
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolverImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/ExceptionResolverImpl.java
@@ -119,7 +119,7 @@ public class ExceptionResolverImpl implements ExceptionResolver {
 			}
 
 			setInfo(trans.alreadySubmitted(getBeanName()),
-					text + trans.visitSubmitted(Window.Location.getHref().split("#")[0], trans.submittedTitle()));
+					text + trans.visitSubmitted(Window.Location.getHref().split("#")[0], application.getId(), trans.submittedTitle()));
 
 		} else if ("MissingRequiredDataException".equalsIgnoreCase(exception.getName())) {
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
@@ -239,8 +239,22 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("Membership extension in {0}")
 	public String extensionDetail(String registerTo);
 
-	@DefaultMessage("Form content")
-	public String formDataTitle();
+	// -------------- APP DETAIL PAGE - EDIT ------------------------ //
+
+	@DefaultMessage("Edit")
+	public String edit();
+
+	@DefaultMessage("Save")
+	public String save();
+
+	@DefaultMessage("Cancel")
+	public String cancel();
+
+	@DefaultMessage("There are no changes to be saved!")
+	public String noChange();
+
+	@DefaultMessage("All changes to the form will be discarded. Do you wish to continue?")
+	public String cancelAsk();
 
 	// --------------- EXCEPTIONS -------------------------------- //
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
@@ -62,6 +62,9 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("Please wait until your application has been approved. You will be notified by email.")
 	public String waitForAcceptation();
 
+	@DefaultMessage("<p><p>You can <b>see or edit your application <a href=\"{0}#appdetail;id={1}\">here</b></a>.")
+	public String seeOrEditApplicationHere(String url, int id);
+
 	@DefaultMessage("Please wait until your application for membership extension has been approved. You will be notified by email.")
 	public String waitForExtAcceptation();
 
@@ -270,8 +273,8 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("You have already submitted extension application to {0}")
 	public String alreadySubmittedExtension(String voName);
 
-	@DefaultMessage("<p>You can check details of your application in <a href=\"{0}#submitted\">{1}</a>.")
-	public String visitSubmitted(String url, String title);
+	@DefaultMessage("<p>You can <b>see or edit your application <a href=\"{0}#appdetail;id={1}\">here</b></a>. You can see all your applications in section <a href=\"{0}#submitted\">{2}</a>.")
+	public String visitSubmitted(String url, int appId, String title);
 
 	@DefaultMessage("You are already registered")
 	public String cantExtendMembership();

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailPresenter.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailPresenter.java
@@ -6,7 +6,6 @@ import com.google.web.bindery.event.shared.EventBus;
 import com.gwtplatform.mvp.client.Presenter;
 import com.gwtplatform.mvp.client.View;
 import com.gwtplatform.mvp.client.annotations.NameToken;
-import com.gwtplatform.mvp.client.annotations.ProxyCodeSplit;
 import com.gwtplatform.mvp.client.annotations.ProxyStandard;
 import com.gwtplatform.mvp.client.proxy.PlaceManager;
 import com.gwtplatform.mvp.client.proxy.ProxyPlace;

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.java
@@ -9,6 +9,7 @@ import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.uibinder.client.UiHandler;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.gwtplatform.mvp.client.ViewImpl;
@@ -16,6 +17,7 @@ import com.gwtplatform.mvp.client.proxy.PlaceManager;
 import cz.metacentrum.perun.wui.client.resources.PerunSession;
 import cz.metacentrum.perun.wui.client.utils.JsUtils;
 import cz.metacentrum.perun.wui.json.ErrorTranslator;
+import cz.metacentrum.perun.wui.json.Events;
 import cz.metacentrum.perun.wui.json.JsonEvents;
 import cz.metacentrum.perun.wui.json.managers.RegistrarManager;
 import cz.metacentrum.perun.wui.model.PerunException;
@@ -33,10 +35,8 @@ import org.gwtbootstrap3.client.ui.html.Paragraph;
 import org.gwtbootstrap3.client.ui.html.Text;
 import org.gwtbootstrap3.extras.notify.client.constants.NotifyType;
 import org.gwtbootstrap3.extras.notify.client.ui.Notify;
-import org.gwtbootstrap3.extras.notify.client.ui.NotifySettings;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 
@@ -96,9 +96,6 @@ public class AppDetailView extends ViewImpl implements AppDetailPresenter.MyView
 	Form formWrapper;
 
 	@UiField
-	Heading formTitle;
-
-	@UiField
 	DescriptionTitle subTitle;
 
 	@UiField
@@ -112,6 +109,10 @@ public class AppDetailView extends ViewImpl implements AppDetailPresenter.MyView
 
 	@UiField
 	Alert state;
+
+	@UiField PerunButton editButton;
+	@UiField PerunButton saveButton;
+	@UiField PerunButton cancelButton;
 
 	@UiField
 	PerunLoader loader;
@@ -135,19 +136,86 @@ public class AppDetailView extends ViewImpl implements AppDetailPresenter.MyView
 	@Inject
 	public AppDetailView(AppDetailViewUiBinder binder) {
 		initWidget(binder.createAndBindUi(this));
-		form.setOnlyPreview(true);
+		editButton.setText(translation.edit());
+		saveButton.setText(translation.save());
+		cancelButton.setText(translation.cancel());
+		form.setFormState(PerunForm.FormState.PREVIEW);
 	}
 
 	@UiHandler(value = "backButton")
 	public void back(ClickEvent event) {
-		placeManager.navigateBack();
+		if (PerunForm.FormState.EDIT.equals(form.getFormState())) {
+			//
+			boolean ok = Window.confirm(translation.cancelAsk());
+			if (ok) {
+				updateState(false);
+				placeManager.navigateBack();
+			}
+		} else {
+			placeManager.navigateBack();
+		}
 	}
+
+	@UiHandler(value = "editButton")
+	public void edit(ClickEvent event) {
+		updateState(true);
+	}
+
+	@UiHandler(value = "cancelButton")
+	public void cancel(ClickEvent event) {
+		updateState(false);
+	}
+
+	@UiHandler(value = "saveButton")
+	public void save(ClickEvent event) {
+		form.submitEditedForm(app, new Events<Boolean>() {
+			@Override
+			public void onFinished(Boolean result) {
+				alertErrorReporter.setVisible(false);
+				saveButton.setProcessing(false);
+				cancelButton.setEnabled(true);
+				updateState(false);
+				// reload whole application state/form from API
+				placeManager.revealCurrentPlace();
+			}
+
+			@Override
+			public void onError(PerunException error) {
+				cancelButton.setEnabled(true);
+				saveButton.setProcessing(false);
+				if (error != null) {
+					alertErrorReporter.setVisible(true);
+					alertErrorReporter.setHTML(ErrorTranslator.getTranslatedMessage(error));
+					alertErrorReporter.setReportInfo(error);
+				} else {
+					Window.alert(translation.noChange());
+				}
+			}
+
+			@Override
+			public void onLoadingStart() {
+				cancelButton.setEnabled(false);
+				saveButton.setProcessing(true);
+				alertErrorReporter.setVisible(false);
+			}
+		});
+	}
+
+	private void updateState(boolean edit) {
+		form.setFormState(edit ? PerunForm.FormState.EDIT : PerunForm.FormState.PREVIEW);
+		form.setFormItems(form.getSourceFormItems());
+		editButton.setVisible(!edit);
+		saveButton.setVisible(edit);
+		cancelButton.setVisible(edit);
+	}
+
 
 	public void draw() {
 
 		form.setSeeHiddenItems(canSeeHiddenFields());
 
-		formTitle.setText(translation.formDataTitle());
+		// hide notice until loaded
+		mailVerificationAlert.setVisible(false);
 
 		if (Application.ApplicationType.INITIAL.equals(app.getType())) {
 			text.setText(translation.initialDetail(app.getVo().getName()));
@@ -179,10 +247,14 @@ public class AppDetailView extends ViewImpl implements AppDetailPresenter.MyView
 		stateTitle.setText(app.getTranslatedState());
 		stateText.setText(app.getModifiedAt().split("\\.")[0]);
 
+		// only new and verified application are editable
+		editButton.setVisible(Application.ApplicationState.NEW.equals(app.getState()) ||
+				Application.ApplicationState.VERIFIED.equals(app.getState()));
+
 	}
 
 	private boolean canSeeHiddenFields() {
-		// TODO - authorization shouldnt be in gui.
+		// TODO - authorization shouldn't be in gui.
 		// admins can see hidden fields - users not
 		PerunSession sess = PerunSession.getInstance();
 		return (sess.isVoAdmin(app.getVo().getId()) || sess.isVoObserver(app.getVo().getId()) || (app.getGroup() != null && sess.isGroupAdmin(app.getGroup().getId())));

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.java
@@ -257,7 +257,7 @@ public class AppDetailView extends ViewImpl implements AppDetailPresenter.MyView
 		// TODO - authorization shouldn't be in gui.
 		// admins can see hidden fields - users not
 		PerunSession sess = PerunSession.getInstance();
-		return (sess.isVoAdmin(app.getVo().getId()) || sess.isVoObserver(app.getVo().getId()) || (app.getGroup() != null && sess.isGroupAdmin(app.getGroup().getId())));
+		return (sess.isPerunAdmin() || sess.isVoAdmin(app.getVo().getId()) || sess.isVoObserver(app.getVo().getId()) || (app.getGroup() != null && sess.isGroupAdmin(app.getGroup().getId())));
 
 	}
 
@@ -341,6 +341,11 @@ public class AppDetailView extends ViewImpl implements AppDetailPresenter.MyView
 				}
 
 				form.setFormItems(list);
+
+				if (form.hasNoVisibleItems() || form.hasNoUpdatableItems()) {
+					editButton.setVisible(false);
+				}
+
 			}
 
 			@Override

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.ui.xml
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppDetailView.ui.xml
@@ -42,7 +42,11 @@
 
 				<b:Form type="HORIZONTAL" ui:field="formWrapper">
 
-					<b:Heading size="H3" text="Form data" ui:field="formTitle"/>
+					<p:PerunToolbar>
+						<p:PerunButton ui:field="editButton" text="Edit" icon="EDIT" />
+						<p:PerunButton ui:field="saveButton" text="Save" icon="SAVE" visible="false" />
+						<p:PerunButton ui:field="cancelButton" text="Cancel" visible="false" />
+					</p:PerunToolbar>
 					<b.html:Hr/>
 
 					<p.registrar:PerunForm ui:field="form">

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsPresenter.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsPresenter.java
@@ -30,7 +30,13 @@ public class AppsPresenter extends Presenter<AppsPresenter.MyView, AppsPresenter
 		super(eventBus, view, proxy, PerunPresenter.SLOT_MAIN_CONTENT);
 	}
 
-/*	@Override
+	@Override
+	protected void onReset() {
+		super.onReset();
+		((AppsView)getView()).draw();
+	}
+
+	/*	@Override
 	protected void onReset() {
 		super.onReset();
 		// resize when any of presenters is attached/detached

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsView.java
@@ -6,6 +6,7 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
+import com.google.gwt.uibinder.client.UiHandler;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.gwtplatform.mvp.client.ViewImpl;
@@ -16,6 +17,7 @@ import cz.metacentrum.perun.wui.model.PerunException;
 import cz.metacentrum.perun.wui.model.beans.Application;
 import cz.metacentrum.perun.wui.registrar.client.resources.PerunRegistrarTranslation;
 import cz.metacentrum.perun.wui.registrar.model.ApplicationColumnProvider;
+import cz.metacentrum.perun.wui.widgets.PerunButton;
 import cz.metacentrum.perun.wui.widgets.PerunDataGrid;
 import org.gwtbootstrap3.client.ui.html.Text;
 
@@ -35,6 +37,9 @@ public class AppsView extends ViewImpl implements AppsPresenter.MyView {
 	@UiField
 	Text text;
 
+	@UiField
+	PerunButton refresh;
+
 	private PerunRegistrarTranslation translation = GWT.create(PerunRegistrarTranslation.class);
 
 	@Inject
@@ -42,11 +47,15 @@ public class AppsView extends ViewImpl implements AppsPresenter.MyView {
 
 		initWidget(binder.createAndBindUi(this));
 		text.setText(translation.submittedTitle());
+		refresh.setTooltipText(translation.refresh());
 		grid.setHeight("100%");
-		draw();
 
 	}
 
+	@UiHandler(value = "refresh")
+	public void refresh(ClickEvent event) {
+		draw();
+	}
 
 	public void draw() {
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsView.ui.xml
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/AppsView.ui.xml
@@ -16,6 +16,7 @@
 			<b:Icon ui:field="icon" type="ARCHIVE" fixedWidth="true" />
 			<b.html:Text text="My registrations" ui:field="text"/>
 			<b.html:Small text=""/>
+			<p:PerunButton tooltipText="Refresh" icon="REFRESH" ui:field="refresh" marginLeft="20" />
 		</b:Heading>
 
 		<g:ResizeLayoutPanel addStyleNames="{res.gss.grid}">

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
@@ -173,6 +173,10 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 			return;
 		}
 
+		// hide previous state
+		hideMailVerificationAlert();
+		hideNotice();
+		form.clear();
 
 		final PerunLoader loader = new PerunLoader();
 		form.add(loader);

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
@@ -4,7 +4,6 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.JavaScriptObject;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
-import com.google.gwt.json.client.JSONObject;
 import com.google.gwt.user.client.Window;
 import cz.metacentrum.perun.wui.client.resources.PerunConfiguration;
 import cz.metacentrum.perun.wui.client.resources.PerunSession;
@@ -18,6 +17,7 @@ import cz.metacentrum.perun.wui.model.beans.Application;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItem;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemData;
 import cz.metacentrum.perun.wui.model.beans.Identity;
+import cz.metacentrum.perun.wui.registrar.client.resources.PerunRegistrarResources;
 import cz.metacentrum.perun.wui.registrar.pages.FormView;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Header;
 import cz.metacentrum.perun.wui.registrar.widgets.items.HtmlComment;
@@ -42,6 +42,12 @@ import java.util.Objects;
  */
 public class PerunForm extends FieldSet {
 
+	public enum FormState {
+		PREFILLED,
+		PREVIEW,
+		EDIT
+	}
+
 	// LABEL_SIZE + WIDGET_WITH_TEXT_SIZE should be 12
 	// LABEL_OFFSET should be same as LABEL_SIZE
 	public static final ColumnSize LABEL_SIZE = ColumnSize.MD_2;
@@ -53,7 +59,7 @@ public class PerunForm extends FieldSet {
 
 	// contains info about onlyPreview and seeHiddenItems
 	private PerunFormItemsGenerator generator;
-	private boolean onlyPreview;
+	private FormState formState;
 	private boolean seeHiddenItems;
 	private Application app;
 	private JsonEvents onSubmitEvent;
@@ -73,30 +79,28 @@ public class PerunForm extends FieldSet {
 	/**
 	 * Create form instance with possibility to set 'only preview' state.
 	 *
-	 * @param onlyPreview TRUE = form will display only preview / FALSE = form will allow editing
+	 * @param formState default is PREFILLED, @see FormState
 	 */
-	public PerunForm(boolean onlyPreview) {
+	public PerunForm(FormState formState) {
 		this();
-		this.onlyPreview = onlyPreview;
+		this.formState = formState;
 	}
 
 	/**
 	 * Create form instance with possibility to set 'only preview' state.
 	 *
-	 * @param onlyPreview TRUE = form will display only preview / FALSE = form will allow editing
+	 * @param formState default is PREFILLED, @see FormState
 	 * @param seeHiddenItems TRUE = form will display also hidden items
 	 */
-	public PerunForm(boolean onlyPreview, boolean seeHiddenItems) {
-		this(onlyPreview);
+	public PerunForm(FormState formState, boolean seeHiddenItems) {
+		this(formState);
 		this.seeHiddenItems = seeHiddenItems;
 	}
 
 	public void addFormItems(List<ApplicationFormItemData> items) {
 
 		if (items != null) {
-
 			addPerunFormItems(generator.generatePerunFormItems(items));
-
 		}
 
 	}
@@ -122,6 +126,10 @@ public class PerunForm extends FieldSet {
 		if (items != null)  {
 
 			for (PerunFormItem item : items) {
+				if (FormState.EDIT.equals(formState) && !item.isUpdatable()) {
+					// distinguish non-editable items
+					item.addStyleName(PerunRegistrarResources.INSTANCE.gss().help());
+				}
 				add(item);
 			}
 			this.items.addAll(items);
@@ -159,12 +167,25 @@ public class PerunForm extends FieldSet {
 	}
 
 	/**
+	 * Get all sourcing form items (not suitable for submit!!)
+	 *
+	 * @return list of source form items with no changes
+	 */
+	public List<ApplicationFormItemData> getSourceFormItems() {
+		List<ApplicationFormItemData> data = new ArrayList<>();
+		for (PerunFormItem item : getPerunFormItems()) {
+			data.add(item.getItemData());
+		}
+		return data;
+	}
+
+	/**
 	 * perform auto submit if form contains auto submit button. Do nothing otherwise.
 	 */
 	public void performAutoSubmit() {
 
 		SubmitButton autoSubmit = getAutoSubmitButton(items);
-		if (autoSubmit != null && !isOnlyPreview()) {
+		if (autoSubmit != null && FormState.PREFILLED.equals(getFormState())) {
 			submit(autoSubmit.getButton());
 		}
 	}
@@ -230,7 +251,7 @@ public class PerunForm extends FieldSet {
 					if (checkSimilarUsersAgain && !PerunConfiguration.findSimilarUsersDisabled()) {
 
 						// validation ok - check similar users
-						RegistrarManager.checkForSimilarUsers(getFormItemData(), new JsonEvents() {
+						RegistrarManager.checkForSimilarUsers(getFormItemDataToSubmit(), new JsonEvents() {
 							@Override
 							public void onFinished(JavaScriptObject result) {
 
@@ -285,6 +306,48 @@ public class PerunForm extends FieldSet {
 
 	}
 
+	public void submitEditedForm(final Application application, final Events<Boolean> events) {
+		validateAll(items, new Events<Boolean>() {
+			@Override
+			public void onFinished(Boolean result) {
+				if (result) {
+					// if everything is valid - submit updated items
+					List<ApplicationFormItemData> data = getFormItemDataToUpdate();
+					if (data.isEmpty()) {
+						events.onError(null);
+					} else {
+						RegistrarManager.updateFormItemsData(application.getId(), data, new JsonEvents() {
+							@Override
+							public void onFinished(JavaScriptObject result) {
+								events.onFinished(true);
+							}
+							@Override
+							public void onError(PerunException error) {
+								events.onError(error);
+							}
+							@Override
+							public void onLoadingStart() {
+							}
+						});
+					}
+				} else {
+					events.onError(null);
+				}
+			}
+
+			@Override
+			public void onError(PerunException error) {
+				events.onError(error);
+			}
+
+			@Override
+			public void onLoadingStart() {
+				events.onLoadingStart();
+			}
+
+		});
+	}
+
 	/**
 	 * Finally send application form to Perun API
 	 *
@@ -292,7 +355,7 @@ public class PerunForm extends FieldSet {
 	 */
 	private void createApplication(final PerunButton button) {
 
-		RegistrarManager.createApplication(app, getFormItemData(), new JsonEvents() {
+		RegistrarManager.createApplication(app, getFormItemDataToSubmit(), new JsonEvents() {
 			@Override
 			public void onFinished(JavaScriptObject jso) {
 
@@ -349,23 +412,26 @@ public class PerunForm extends FieldSet {
 
 		for (final PerunFormItem item : items) {
 
-			// for anonymous users
-			if (PerunSession.getInstance().getUser() == null) {
+			if (FormState.PREFILLED.equals(formState)) {
 
-				String prefilledValue = item.getItemData().getPrefilledValue();
+				// for anonymous users
+				if (PerunSession.getInstance().getUser() == null) {
 
-				if (Objects.equals(item.getItemData().getFormItem().getType(), ApplicationFormItem.ApplicationFormItemType.VALIDATED_EMAIL)) {
-					if (prefilledValue == null || !prefilledValue.contains(item.getValue())) {
-						// mail changed - re-check existing users
-						checkSimilarUsersAgain = true;
+					String prefilledValue = item.getItemData().getPrefilledValue();
+
+					if (Objects.equals(item.getItemData().getFormItem().getType(), ApplicationFormItem.ApplicationFormItemType.VALIDATED_EMAIL)) {
+						if (prefilledValue == null || !prefilledValue.contains(item.getValue())) {
+							// mail changed - re-check existing users
+							checkSimilarUsersAgain = true;
+						}
+					} else if (Objects.equals(item.getItemData().getFormItem().getPerunDestinationAttribute(), "urn:perun:user:attribute-def:core:displayName")) {
+						if (!Objects.equals(prefilledValue, item.getValue())) {
+							// name changed - re-check existing users
+							checkSimilarUsersAgain = true;
+						}
 					}
-				} else if (Objects.equals(item.getItemData().getFormItem().getPerunDestinationAttribute(), "urn:perun:user:attribute-def:core:displayName")) {
-					if (!Objects.equals(prefilledValue, item.getValue())) {
-						// name changed - re-check existing users
-						checkSimilarUsersAgain = true;
-					}
+
 				}
-
 			}
 
 			item.validate(new Events<Boolean>() {
@@ -412,21 +478,21 @@ public class PerunForm extends FieldSet {
 
 
 	/**
-	 * Is form meant only for preview
+	 * Return state of the form, default is PREFILLED, can be PREVIEW and EDIT
 	 *
-	 * @return TRUE = preview / FALSE = editing
+	 * @return FormState
 	 */
-	public boolean isOnlyPreview() {
-		return this.onlyPreview;
+	public FormState getFormState() {
+		return this.formState;
 	}
 
 	/**
-	 * Set form as meant only for preview
+	 * Set form state, default is PREFILLED, can be PREVIEW and EDIT
 	 *
-	 * @param onlyPreview TRUE = for preview / FALSE = for editing
+	 * @param  formState default is PREFILLED, @see FormState
 	 */
-	public void setOnlyPreview(boolean onlyPreview) {
-		this.onlyPreview = onlyPreview;
+	public void setFormState(FormState formState) {
+		this.formState = formState;
 	}
 
 	public boolean isSeeHiddenItems() {
@@ -453,7 +519,7 @@ public class PerunForm extends FieldSet {
 		this.onSubmitEvent = onSubmitEvent;
 	}
 
-	private List<ApplicationFormItemData> getFormItemData() {
+	private List<ApplicationFormItemData> getFormItemDataToSubmit() {
 
 		// convert data
 		List<ApplicationFormItemData> data = new ArrayList<ApplicationFormItemData>();
@@ -461,13 +527,19 @@ public class PerunForm extends FieldSet {
 
 			String value = item.getValue();
 			String prefilled = item.getItemData().getPrefilledValue();
-			JSONObject formItemJSON = new JSONObject(item.getItemData().getFormItem());
 
 			// remove text (locale), saves data transfer & removes problem with parsing locale
-			formItemJSON.put("i18n", new JSONObject());
-
-			// cast form item back
-			ApplicationFormItem formItem = formItemJSON.getJavaScriptObject().cast();
+			ApplicationFormItem formItem = ApplicationFormItem.createNew(item.getItemData().getFormItem().getId(),
+					item.getItemData().getFormItem().getShortname(),
+					item.getItemData().getFormItem().isRequired(),
+					item.getItemData().getFormItem().getType(),
+					item.getItemData().getFormItem().getFederationAttribute(),
+					item.getItemData().getFormItem().getPerunSourceAttribute(),
+					item.getItemData().getFormItem().getPerunDestinationAttribute(),
+					item.getItemData().getFormItem().getRegex(),
+					item.getItemData().getFormItem().getApplicationTypes(),
+					item.getItemData().getFormItem().getOrdnum(),
+					item.getItemData().getFormItem().isForDelete());
 
 			// clear pre-filled value if login was generated, since we want server to register new login
 			if (ApplicationFormItem.ApplicationFormItemType.USERNAME.equals(formItem.getType()) &&
@@ -478,6 +550,53 @@ public class PerunForm extends FieldSet {
 			// prepare package with data
 			ApplicationFormItemData itemData = ApplicationFormItemData.construct(formItem, formItem.getShortname(), value, prefilled, item.getItemData().getAssuranceLevel() != null ? item.getItemData().getAssuranceLevel() : "");
 
+			data.add(itemData);
+
+		}
+
+		return data;
+
+	}
+
+	private List<ApplicationFormItemData> getFormItemDataToUpdate() {
+
+		// convert data
+		List<ApplicationFormItemData> data = new ArrayList<ApplicationFormItemData>();
+		for (PerunFormItem item : items) {
+
+			// skip non-updatable form items
+			if (!item.isUpdatable()) continue;
+
+			if (Objects.equals(item.getItemData().getValue(), item.getValue())) {
+				// value within item and form item is same -> unchanged -> do not update
+				continue;
+			}
+
+			String value = item.getValue();
+			String prefilled = item.getItemData().getPrefilledValue();
+
+			// clear pre-filled value if login was generated, since we want server to register new login
+			if (ApplicationFormItem.ApplicationFormItemType.USERNAME.equals(item.getItemData().getFormItem().getType()) &&
+					item.getItemData().isGenerated()) {
+				prefilled = "";
+			}
+
+			// remove text (locale), saves data transfer & removes problem with parsing locale
+			ApplicationFormItem formItem = ApplicationFormItem.createNew(item.getItemData().getFormItem().getId(),
+					item.getItemData().getFormItem().getShortname(),
+					item.getItemData().getFormItem().isRequired(),
+					item.getItemData().getFormItem().getType(),
+					item.getItemData().getFormItem().getFederationAttribute(),
+					item.getItemData().getFormItem().getPerunSourceAttribute(),
+					item.getItemData().getFormItem().getPerunDestinationAttribute(),
+					item.getItemData().getFormItem().getRegex(),
+					item.getItemData().getFormItem().getApplicationTypes(),
+					item.getItemData().getFormItem().getOrdnum(),
+					item.getItemData().getFormItem().isForDelete());
+
+			// prepare package with data
+			ApplicationFormItemData itemData = ApplicationFormItemData.construct(formItem, item.getItemData().getFormItem().getShortname(), value, prefilled, item.getItemData().getAssuranceLevel() != null ? item.getItemData().getAssuranceLevel() : "");
+			itemData.setId(item.getItemData().getId());
 			data.add(itemData);
 
 		}

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
@@ -136,7 +136,8 @@ public class PerunForm extends FieldSet {
 
 		}
 
-		if (this.items.isEmpty()) {
+		if (this.items.isEmpty() ||
+				(FormState.PREVIEW.equals(formState) && hasNoVisibleItems())) {
 			add(new Heading(HeadingSize.H2, "", perunTranslation.formHasNoFormItems()));
 		}
 
@@ -603,6 +604,30 @@ public class PerunForm extends FieldSet {
 
 		return data;
 
+	}
+
+	/**
+	 * Return TRUE if form is empty, or has no "visible" items
+	 * @return
+	 */
+	public boolean hasNoVisibleItems() {
+		for (PerunFormItem item : items) {
+			if (item.isVisible())
+				return false;
+		}
+		return true;
+	}
+
+	/**
+	 * Return TRUE if form is empty, or has no "updatable" items
+	 * @return
+	 */
+	public boolean hasNoUpdatableItems() {
+		for (PerunFormItem item : items) {
+			if (item.isUpdatable())
+				return false;
+		}
+		return true;
 	}
 
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
@@ -61,15 +61,15 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 	private PerunFormItem generatePerunFormItem(ApplicationFormItemData data) {
 
 		String lang = PerunConfiguration.getCurrentLocaleName();
-		boolean onlyPreview = form.isOnlyPreview();
+		PerunForm.FormState formState = form.getFormState();
 
 		switch (data.getFormItem().getType()) {
 			case HEADING:
-				return new Header(form ,data, lang);
+				return new Header(form, data, lang);
 			case TEXTFIELD:
-				return new TextField(form, data, lang, onlyPreview);
+				return new TextField(form, data, lang, formState);
 			case VALIDATED_EMAIL:
-				return new ValidatedEmail(form, data, lang, onlyPreview);
+				return new ValidatedEmail(form, data, lang, formState);
 			case TEXTAREA:
 				// FIXME - hack for BBMRI collections to pre-fill value from URL
 				if ((data.getValue() == null || data.getValue().isEmpty() || data.getValue().equals("null")) &&
@@ -78,29 +78,29 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 					final String bbmriCollections = Window.Location.getParameter("col");
 					data.setPrefilledValue((bbmriCollections != null) ? JsUtils.unzipString(JsUtils.decodeBase64(bbmriCollections.replaceAll(" ", "+"))) : null);
 				}
-				return new TextArea(form, data, lang, onlyPreview);
+				return new TextArea(form, data, lang, formState);
 			case USERNAME:
-				Username username = new Username(form, data, lang, onlyPreview);
+				Username username = new Username(form, data, lang, formState);
 				if (data.getPrefilledValue() != null && !data.getPrefilledValue().isEmpty() && !data.isGenerated()) {
 					username.setEnable(false);
 				}
 				return username;
 			case PASSWORD:
-				return new Password(form, data, lang, onlyPreview);
+				return new Password(form, data, lang, formState);
 			case TIMEZONE:
-				return new Timezone(form, data, lang, onlyPreview);
+				return new Timezone(form, data, lang, formState);
 			case SELECTIONBOX:
-				return new Selectionbox(form, data, lang, onlyPreview);
+				return new Selectionbox(form, data, lang, formState);
 			case COMBOBOX:
-				return new Combobox(form, data, lang, onlyPreview);
+				return new Combobox(form, data, lang, formState);
 			case CHECKBOX:
-				return new Checkbox(form, data, lang, onlyPreview);
+				return new Checkbox(form, data, lang, formState);
 			case RADIO:
-				return new Radiobox(form, data, lang, onlyPreview);
+				return new Radiobox(form, data, lang, formState);
 			case FROM_FEDERATION_SHOW:
-				return new FromFederation(form, data, lang, onlyPreview);
+				return new FromFederation(form, data, lang, formState);
 			case FROM_FEDERATION_HIDDEN:
-				FromFederation hidden = new FromFederation(form, data, lang, onlyPreview);
+				FromFederation hidden = new FromFederation(form, data, lang, formState);
 				if (!form.isSeeHiddenItems()) {
 					hidden.setVisible(false);
 				} else {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
@@ -61,15 +61,14 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 	private PerunFormItem generatePerunFormItem(ApplicationFormItemData data) {
 
 		String lang = PerunConfiguration.getCurrentLocaleName();
-		PerunForm.FormState formState = form.getFormState();
 
 		switch (data.getFormItem().getType()) {
 			case HEADING:
 				return new Header(form, data, lang);
 			case TEXTFIELD:
-				return new TextField(form, data, lang, formState);
+				return new TextField(form, data, lang);
 			case VALIDATED_EMAIL:
-				return new ValidatedEmail(form, data, lang, formState);
+				return new ValidatedEmail(form, data, lang);
 			case TEXTAREA:
 				// FIXME - hack for BBMRI collections to pre-fill value from URL
 				if ((data.getValue() == null || data.getValue().isEmpty() || data.getValue().equals("null")) &&
@@ -78,29 +77,29 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 					final String bbmriCollections = Window.Location.getParameter("col");
 					data.setPrefilledValue((bbmriCollections != null) ? JsUtils.unzipString(JsUtils.decodeBase64(bbmriCollections.replaceAll(" ", "+"))) : null);
 				}
-				return new TextArea(form, data, lang, formState);
+				return new TextArea(form, data, lang);
 			case USERNAME:
-				Username username = new Username(form, data, lang, formState);
+				Username username = new Username(form, data, lang);
 				if (data.getPrefilledValue() != null && !data.getPrefilledValue().isEmpty() && !data.isGenerated()) {
 					username.setEnable(false);
 				}
 				return username;
 			case PASSWORD:
-				return new Password(form, data, lang, formState);
+				return new Password(form, data, lang);
 			case TIMEZONE:
-				return new Timezone(form, data, lang, formState);
+				return new Timezone(form, data, lang);
 			case SELECTIONBOX:
-				return new Selectionbox(form, data, lang, formState);
+				return new Selectionbox(form, data, lang);
 			case COMBOBOX:
-				return new Combobox(form, data, lang, formState);
+				return new Combobox(form, data, lang);
 			case CHECKBOX:
-				return new Checkbox(form, data, lang, formState);
+				return new Checkbox(form, data, lang);
 			case RADIO:
-				return new Radiobox(form, data, lang, formState);
+				return new Radiobox(form, data, lang);
 			case FROM_FEDERATION_SHOW:
-				return new FromFederation(form, data, lang, formState);
+				return new FromFederation(form, data, lang);
 			case FROM_FEDERATION_HIDDEN:
-				FromFederation hidden = new FromFederation(form, data, lang, formState);
+				FromFederation hidden = new FromFederation(form, data, lang);
 				if (!form.isSeeHiddenItems()) {
 					hidden.setVisible(false);
 				} else {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Checkbox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Checkbox.java
@@ -29,8 +29,8 @@ public class Checkbox extends PerunFormItemEditable {
 
 	private FlowPanel widget;
 
-	public Checkbox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public Checkbox(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new CheckboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Checkbox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Checkbox.java
@@ -29,8 +29,8 @@ public class Checkbox extends PerunFormItemEditable {
 
 	private FlowPanel widget;
 
-	public Checkbox(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public Checkbox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new CheckboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Combobox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Combobox.java
@@ -36,8 +36,8 @@ public class Combobox extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public Combobox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public Combobox(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new ComboboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Combobox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Combobox.java
@@ -1,6 +1,5 @@
 package cz.metacentrum.perun.wui.registrar.widgets.items;
 
-import com.google.gwt.core.client.GWT;
 import com.google.gwt.event.dom.client.BlurEvent;
 import com.google.gwt.event.dom.client.BlurHandler;
 import com.google.gwt.event.dom.client.ChangeEvent;
@@ -9,7 +8,6 @@ import com.google.gwt.user.client.ui.Panel;
 import com.google.gwt.user.client.ui.Widget;
 import cz.metacentrum.perun.wui.json.Events;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemData;
-import cz.metacentrum.perun.wui.registrar.client.resources.PerunRegistrarTranslation;
 import cz.metacentrum.perun.wui.registrar.widgets.PerunForm;
 import cz.metacentrum.perun.wui.registrar.widgets.Select;
 import cz.metacentrum.perun.wui.registrar.widgets.items.validators.ComboboxValidator;
@@ -38,8 +36,8 @@ public class Combobox extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public Combobox(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public Combobox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new ComboboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/FromFederation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/FromFederation.java
@@ -19,8 +19,8 @@ public class FromFederation extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public FromFederation(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public FromFederation(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 	}
 
 	@Override
@@ -125,6 +125,17 @@ public class FromFederation extends PerunFormItemEditable {
 			return (Paragraph) widget;
 		}
 		return null;
+	}
+
+	@Override
+	public boolean isOnlyPreview() {
+		return super.isOnlyPreview() || PerunForm.FormState.EDIT.equals(getForm().getFormState());
+	}
+
+	@Override
+	public boolean isUpdatable() {
+		// non editable items can't' be updated once submitted
+		return false;
 	}
 
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/FromFederation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/FromFederation.java
@@ -19,8 +19,8 @@ public class FromFederation extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public FromFederation(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public FromFederation(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 	}
 
 	@Override

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Password.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Password.java
@@ -28,8 +28,8 @@ public class Password extends PerunFormItemEditable {
 
 	private InputGroup widget;
 
-	public Password(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public Password(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		// FIXME - specific per-namespace validation
 		if (item.getFormItem() != null && Objects.equals("urn:perun:user:attribute-def:def:login-namespace:einfra", item.getFormItem().getPerunDestinationAttribute())) {
 				this.validator = new EinfraPasswordValidator();

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Password.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Password.java
@@ -28,8 +28,8 @@ public class Password extends PerunFormItemEditable {
 
 	private InputGroup widget;
 
-	public Password(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public Password(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		// FIXME - specific per-namespace validation
 		if (item.getFormItem() != null && Objects.equals("urn:perun:user:attribute-def:def:login-namespace:einfra", item.getFormItem().getPerunDestinationAttribute())) {
 				this.validator = new EinfraPasswordValidator();
@@ -156,6 +156,17 @@ public class Password extends PerunFormItemEditable {
 
 	public PasswordValidator getValidator() {
 		return this.validator;
+	}
+
+	@Override
+	public boolean isOnlyPreview() {
+		return super.isOnlyPreview() || PerunForm.FormState.EDIT.equals(getForm().getFormState());
+	}
+
+	@Override
+	public boolean isUpdatable() {
+		// password can't' be updated once submitted
+		return false;
 	}
 
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItem.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItem.java
@@ -138,4 +138,14 @@ public abstract class PerunFormItem extends FormGroup {
 		return "";
 	}
 
+	/**
+	 * Return TRUE if form item can be "updated" once form is submitted.
+	 * We can update only items with non-null "ApplicationFormItem" property.
+	 *
+	 * @return default TRUE
+	 */
+	public boolean isUpdatable() {
+		return getItemData().getFormItem() != null;
+	}
+
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
@@ -29,12 +29,10 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 	private FormLabel label;
 	private HelpBlock status;
 	private HelpBlock help;
-	private final PerunForm.FormState formState;
 	public PerunRegistrarTranslation translation = GWT.create(PerunRegistrarTranslation.class);
 
-	public PerunFormItemEditable(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+	public PerunFormItemEditable(PerunForm form, ApplicationFormItemData item, String lang) {
 		super(form, item, lang);
-		this.formState = formState;
 		add(initFormItem());
 		if (!isOnlyPreview()) {
 			setValidationTriggers();
@@ -92,7 +90,7 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 
 			widget.add(initWidget());
 
-			if (formState.equals(PerunForm.FormState.EDIT)) {
+			if (PerunForm.FormState.EDIT.equals(getForm().getFormState())) {
 				// value already stored in item
 				setValue(getItemData().getValue());
 			} else {
@@ -189,7 +187,7 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 	}
 
 	public boolean isOnlyPreview() {
-		return PerunForm.FormState.PREVIEW.equals(formState);
+		return PerunForm.FormState.PREVIEW.equals(getForm().getFormState());
 	}
 
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
@@ -29,12 +29,12 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 	private FormLabel label;
 	private HelpBlock status;
 	private HelpBlock help;
-	private final boolean onlyPreview;
+	private final PerunForm.FormState formState;
 	public PerunRegistrarTranslation translation = GWT.create(PerunRegistrarTranslation.class);
 
-	public PerunFormItemEditable(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
+	public PerunFormItemEditable(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
 		super(form, item, lang);
-		this.onlyPreview = onlyPreview;
+		this.formState = formState;
 		add(initFormItem());
 		if (!isOnlyPreview()) {
 			setValidationTriggers();
@@ -78,7 +78,6 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 		item.add(label);
 		item.add(widgetWithTexts);
 
-
 		if (isOnlyPreview()) {
 
 			statusWrap.setVisible(false);
@@ -92,7 +91,14 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 		} else {
 
 			widget.add(initWidget());
-			setValue(getItemData().getPrefilledValue());
+
+			if (formState.equals(PerunForm.FormState.EDIT)) {
+				// value already stored in item
+				setValue(getItemData().getValue());
+			} else {
+				// value pre-filled by perun (default on sending new form)
+				setValue(getItemData().getPrefilledValue());
+			}
 
 			String helpText = getItemData().getFormItem().getItemTexts(getLang()).getHelp();
 			if (helpText == null) {
@@ -183,7 +189,7 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 	}
 
 	public boolean isOnlyPreview() {
-		return onlyPreview;
+		return PerunForm.FormState.PREVIEW.equals(formState);
 	}
 
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemStatic.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemStatic.java
@@ -48,4 +48,10 @@ public abstract class PerunFormItemStatic extends PerunFormItem {
 		// do nothing.
 	}
 
+	@Override
+	public boolean isUpdatable() {
+		// static items can't be updated
+		return false;
+	}
+
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Radiobox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Radiobox.java
@@ -29,8 +29,8 @@ public class Radiobox extends PerunFormItemEditable {
 
 	private FlowPanel widget;
 
-	public Radiobox(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public Radiobox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new RadioboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Radiobox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Radiobox.java
@@ -29,8 +29,8 @@ public class Radiobox extends PerunFormItemEditable {
 
 	private FlowPanel widget;
 
-	public Radiobox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public Radiobox(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new RadioboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Selectionbox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Selectionbox.java
@@ -28,8 +28,8 @@ public class Selectionbox extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public Selectionbox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public Selectionbox(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new SelectionboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Selectionbox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Selectionbox.java
@@ -28,8 +28,8 @@ public class Selectionbox extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public Selectionbox(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public Selectionbox(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new SelectionboxValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextArea.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextArea.java
@@ -23,8 +23,8 @@ public class TextArea extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public TextArea(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public TextArea(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new TextAreaValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextArea.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextArea.java
@@ -23,8 +23,8 @@ public class TextArea extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public TextArea(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public TextArea(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new TextAreaValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextField.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextField.java
@@ -24,8 +24,8 @@ public class TextField extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public TextField(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public TextField(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new TextFieldValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextField.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextField.java
@@ -24,8 +24,8 @@ public class TextField extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public TextField(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public TextField(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new TextFieldValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Timezone.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Timezone.java
@@ -27,8 +27,8 @@ public class Timezone extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public Timezone(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public Timezone(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new TimezoneValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Timezone.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Timezone.java
@@ -27,8 +27,8 @@ public class Timezone extends PerunFormItemEditable {
 
 	private Widget widget;
 
-	public Timezone(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public Timezone(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new TimezoneValidator();
 	}
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
@@ -30,8 +30,8 @@ public class Username extends PerunFormItemEditable {
 
 	private InputGroup widget;
 
-	public Username(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public Username(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		if (item.getFormItem() != null && Objects.equals("urn:perun:user:attribute-def:def:login-namespace:einfra", item.getFormItem().getPerunDestinationAttribute())) {
 			this.validator = new EinfraUsernameValidator();
 		} else {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
@@ -30,8 +30,8 @@ public class Username extends PerunFormItemEditable {
 
 	private InputGroup widget;
 
-	public Username(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public Username(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		if (item.getFormItem() != null && Objects.equals("urn:perun:user:attribute-def:def:login-namespace:einfra", item.getFormItem().getPerunDestinationAttribute())) {
 			this.validator = new EinfraUsernameValidator();
 		} else {
@@ -76,7 +76,7 @@ public class Username extends PerunFormItemEditable {
 
 	@Override
 	public void validate(Events<Boolean> events) {
-		if (getTextBox().isEnabled()) {
+		if (!isOnlyPreview() && getTextBox().isEnabled()) {
 			validator.validate(this, events);
 		} else {
 			events.onLoadingStart();
@@ -86,7 +86,7 @@ public class Username extends PerunFormItemEditable {
 
 	@Override
 	public boolean validateLocal() {
-		if (getTextBox().isEnabled()) {
+		if (!isOnlyPreview() && getTextBox().isEnabled()) {
 			return validator.validateLocal(this);
 		}
 		return true;
@@ -186,4 +186,16 @@ public class Username extends PerunFormItemEditable {
 	public void setEnable(boolean enable) {
 		getTextBox().setEnabled(enable);
 	}
+
+	@Override
+	public boolean isOnlyPreview() {
+		return super.isOnlyPreview() || PerunForm.FormState.EDIT.equals(getForm().getFormState());
+	}
+
+	@Override
+	public boolean isUpdatable() {
+		// username can't' be updated once submitted
+		return false;
+	}
+
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
@@ -38,10 +38,10 @@ public class ValidatedEmail extends PerunFormItemEditable {
 
 	private InputGroup widget;
 
-	public ValidatedEmail(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
-		super(form, item, lang, formState);
+	public ValidatedEmail(PerunForm form, ApplicationFormItemData item, String lang) {
+		super(form, item, lang);
 		this.validator = new ValidatedEmailValidator();
-		if (formState.equals(PerunForm.FormState.EDIT)) {
+		if (PerunForm.FormState.EDIT.equals(getForm().getFormState())) {
 			// make sure we consider current value as verified based on LoA when editing form
 			item.setPrefilledValue(item.getValue());
 		}

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
@@ -38,9 +38,13 @@ public class ValidatedEmail extends PerunFormItemEditable {
 
 	private InputGroup widget;
 
-	public ValidatedEmail(PerunForm form, ApplicationFormItemData item, String lang, boolean onlyPreview) {
-		super(form, item, lang, onlyPreview);
+	public ValidatedEmail(PerunForm form, ApplicationFormItemData item, String lang, PerunForm.FormState formState) {
+		super(form, item, lang, formState);
 		this.validator = new ValidatedEmailValidator();
+		if (formState.equals(PerunForm.FormState.EDIT)) {
+			// make sure we consider current value as verified based on LoA when editing form
+			item.setPrefilledValue(item.getValue());
+		}
 	}
 
 	protected Widget initWidget() {

--- a/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
+++ b/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
@@ -93,7 +93,14 @@ mailVerificationRequestSent=Zpráva pro ověření mailu odeslána na <b>{0}</b>
 detailDefaultTitle=Detail registrace
 initialDetail=Registrace do {0}
 extensionDetail=Prodloužení členství v {0}
-formDataTitle=Obsah formuláře
+
+# // -------------- APP DETAIL PAGE - EDIT ------------------------ //
+
+edit=Upravit
+save=Uložit
+cancel=Zrušit
+noChange=Formulář nebsahuje žádné změny k uložení!
+cancelAsk=Všechny změny ve formuláři budou zahozeny. Chcete pokračovat?
 
 # // --------------- EXCEPTIONS -------------------------------- //
 

--- a/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
+++ b/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
@@ -25,6 +25,7 @@ extendTitleAutoApproval=Úspěšně jste prodloužil členství
 
 verifyMail=Prosím zkontrolujte si poštovní schránku {0} a ověřte Vaši e-mailovou adresu. Bez ověření není možné Vaši žádost schválit.
 waitForAcceptation=Prosím vyčkejte dokud administrátor neschválí Vaši žádost. O schválení nebo zamítnutí budete informován e-mailem.
+seeOrEditApplicationHere=<p><p>Přihlášku si můžete <b>zkontrolovat nebo upravit <a href="{0}#appdetail;id={1}">zde</b></a>.
 waitForExtAcceptation=Prosím vyčkejte dokud administrátor neschválí Vaši žádost o prodloužení. O schválení nebo zamítnutí budete informován e-mailem.
 waitForVoAcceptation=Po schválení se stanete členem "{0}" automaticky.
 waitForVoExtension=Po schválení se stanete členem "{0}" automaticky.
@@ -108,7 +109,7 @@ continueButton=Pokračovat
 alreadyRegistered=Již jste registrován(a) v {0}
 alreadySubmitted=Již máte podanou přihlášku do {0}
 alreadySubmittedExtension=Již máte podanou žádost o prodloužení členství v {0}
-visitSubmitted=<p>Detaily podané přihlášky můžete zkontrolovat v části <a href="{0}#submitted">{1}</a>.
+visitSubmitted=<p>Přihlášku si můžete <b>zkontrolovat nebo upravit <a href="{0}#appdetail;id={1}">zde</b></a>. Přehled všech přihlášek naleznete v části <a href="{0}#submitted">{2}</a>.
 cantExtendMembership=Již jste členem
 cantExtendMembershipOutside=<br/>Vaše členství v <i>{1}</i> je platné do <b>{0}</b>.
 cantExtendMembershipInsufficientLoa=Pro prodloužení členství nemáte dostatečně ověřenou identitu (LoA = Level of Assurance). Kontaktujte svého poskytovatele identity ({0}) a prokažte mu svoji identitu předložením oficiálního dokladu (občanský průkaz, pas). Pokud máte k dispozici jinou identitu s vyšším stupněm ověření, zkuste se přihlásit pomocí ní.


### PR DESCRIPTION
- We want users to be able to edit submitted applications.
- Added new api callback for it.
- PerunForm can now have 3 states, PREFILLED (initial on
  submission), EDIT (editing submitted) and PREVIEW.
  Each form item respect these states individually. Some
  form items are not editable/updatable (eg. login,
  non-editable fields).
  Also form items data of deleted template form item are
  not editable.
- Reworked, how we construct form item data before submission.
- Do not display mail verification notice on applications not
  related to mail to be verified.