### PR TITLE
Fixed format of current date string in JsUtils

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/utils/JsUtils.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/client/utils/JsUtils.java
@@ -326,6 +326,12 @@ public class JsUtils {
 		var currentDate = new Date();
 		var day = currentDate.getDate();
 		var month = currentDate.getMonth() + 1;
+		if (day < 10) {
+			day = '0' + day;
+		}
+		if (month < 10) {
+			month = '0' + month;
+		}
 		var year = currentDate.getFullYear();
 		return year + "-" + month + "-" + day;
 	}-*/;


### PR DESCRIPTION
- Pre-pend '0' if day or month is < 10.