### PR TITLE
Registrar - items rework

### DIFF
--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItem.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItem.java
@@ -25,8 +25,6 @@ public class ApplicationFormItem extends JavaScriptObject {
 		HTML_COMMENT,
 		SUBMIT_BUTTON,
 		AUTO_SUBMIT_BUTTON,
-		FROM_FEDERATION_SHOW,
-		FROM_FEDERATION_HIDDEN,
 		PASSWORD,
 		VALIDATED_EMAIL,
 		TEXTFIELD,
@@ -38,6 +36,20 @@ public class ApplicationFormItem extends JavaScriptObject {
 		USERNAME,
 		HEADING,
 		TIMEZONE
+	}
+
+	public enum Hidden {
+		NEVER,
+		ALWAYS,
+		IF_PREFILLED,
+		IF_EMPTY
+	}
+
+	public enum Disabled {
+		NEVER,
+		ALWAYS,
+		IF_PREFILLED,
+		IF_EMPTY
 	}
 
 	protected ApplicationFormItem() {}
@@ -376,6 +388,53 @@ public class ApplicationFormItem extends JavaScriptObject {
 	 */
 	public final native void setEdited(boolean edited) /*-{
 		this.edited = edited;
+	}-*/;
+
+	public final boolean isUpdatable() {
+		return JsUtils.getNativePropertyBoolean(this, "updatable");
+	}
+
+	public final native void setUpdatable(boolean updatable) /*-{
+		this.updatable = updatable;
+	}-*/;
+
+	public final native Integer getHiddenDependencyItemId() /*-{
+		return this.hiddenDependencyItemId;
+	}-*/;
+
+	public final native Integer getDisabledDependencyItemId() /*-{
+		return this.disabledDependencyItemId;
+	}-*/;
+
+	public final native void setHiddenDependencyItemId(Integer itemId) /*-{
+		this.hiddenDependencyItemId = itemId;
+	}-*/;
+
+	public final native void setDisabledDependencyItemId(Integer itemId) /*-{
+		this.disabledDependencyItemId = itemId;
+	}-*/;
+
+	public final Disabled getDisabled() {
+		return Disabled.valueOf(JsUtils.getNativePropertyString(this, "disabled"));
+	}
+	public final Hidden getHidden() {
+		return Hidden.valueOf(JsUtils.getNativePropertyString(this, "hidden"));
+	}
+
+	public final void setDisabled(Disabled disabled) {
+		setDisabled(String.valueOf(disabled));
+	}
+
+	private native void setDisabled(String disabled) /*-{
+		this.disabled = disabled;
+	}-*/;
+
+	public final void setHidden(Hidden hidden) {
+		setHidden(String.valueOf(hidden));
+	}
+
+	private native void setHidden(String hidden) /*-{
+		this.hidden = hidden;
 	}-*/;
 
 	/**

--- a/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItemData.java
+++ b/perun-wui-core/src/main/java/cz/metacentrum/perun/wui/model/beans/ApplicationFormItemData.java
@@ -203,4 +203,5 @@ public class ApplicationFormItemData extends JavaScriptObject {
 		return o.getShortname().equals(this.getShortname());
 	}
 
+
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunForm.java
@@ -176,6 +176,9 @@ public class PerunForm extends FieldSet {
 		List<ApplicationFormItemData> data = new ArrayList<>();
 		for (PerunFormItem item : getPerunFormItems()) {
 			data.add(item.getItemData());
+			if (!item.isUpdatable()) {
+				item.getItemData().getFormItem().setDisabled(ApplicationFormItem.Disabled.ALWAYS);
+			}
 		}
 		return data;
 	}

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/PerunFormItemsGeneratorImpl.java
@@ -4,15 +4,17 @@ import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Window;
 import cz.metacentrum.perun.wui.client.resources.PerunConfiguration;
 import cz.metacentrum.perun.wui.client.utils.JsUtils;
+import cz.metacentrum.perun.wui.model.beans.ApplicationFormItem;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemData;
+import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemTexts;
 import cz.metacentrum.perun.wui.registrar.client.resources.PerunRegistrarTranslation;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Checkbox;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Combobox;
-import cz.metacentrum.perun.wui.registrar.widgets.items.FromFederation;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Header;
 import cz.metacentrum.perun.wui.registrar.widgets.items.HtmlComment;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Password;
 import cz.metacentrum.perun.wui.registrar.widgets.items.PerunFormItem;
+import cz.metacentrum.perun.wui.registrar.widgets.items.PerunFormItemEditable;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Radiobox;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Selectionbox;
 import cz.metacentrum.perun.wui.registrar.widgets.items.SubmitButton;
@@ -22,12 +24,15 @@ import cz.metacentrum.perun.wui.registrar.widgets.items.Timezone;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Undefined;
 import cz.metacentrum.perun.wui.registrar.widgets.items.Username;
 import cz.metacentrum.perun.wui.registrar.widgets.items.ValidatedEmail;
-import org.gwtbootstrap3.client.ui.Icon;
-import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.client.ui.constants.ValidationState;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toMap;
 
 /**
  * @author Ondrej Velisek <ondrejvelisek@gmail.com>
@@ -43,6 +48,10 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 
 	@Override
 	public List<PerunFormItem> generatePerunFormItems(List<ApplicationFormItemData> items) {
+		Map<Integer, ApplicationFormItemData> formItemsByIds = items.stream()
+//				.peek(value -> GWT.log(String.valueOf(value.getFormItem().getId())))
+				.collect(toMap(item -> item.getFormItem().getId(), Function.identity()));
+
 
 		List<PerunFormItem> perunFormItems = new ArrayList<>();
 		int i = 0;
@@ -50,18 +59,139 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 
 			if (i != -1) {
 				PerunFormItem perunFormItem = generatePerunFormItem(item);
+				if (isItemHidden(perunFormItem, formItemsByIds)) {
+					perunFormItem.setVisible(false);
+					if (perunFormItem instanceof PerunFormItemEditable) {
+						((PerunFormItemEditable) perunFormItem).setRawStatus("", ValidationState.NONE);
+					}
+				}
+				if (isItemDisabled(perunFormItem, formItemsByIds)) {
+					if (perunFormItem instanceof PerunFormItemEditable) {
+						((PerunFormItemEditable) perunFormItem).setEnabled(false);
+					}
+				}
 				perunFormItems.add(perunFormItem);
 			}
 
 			i++;
 		}
+
 		return perunFormItems;
 	}
+
+	private boolean isItemHidden(PerunFormItem formItem,
+	                             Map<Integer, ApplicationFormItemData> allItemsByIds) {
+		switch (formItem.getItemData().getFormItem().getHidden()) {
+			case NEVER:
+				return false;
+			case ALWAYS:
+				return true;
+			case IF_EMPTY:
+				return isItemHiddenForValidator(formItem, allItemsByIds, this::isItemEmpty);
+			case IF_PREFILLED:
+				return isItemHiddenForValidator(formItem, allItemsByIds, this::isItemPrefilled);
+			default:
+				return false;
+		}
+	}
+
+	private boolean isBlank(String s) {
+		return s == null || s.trim().isEmpty();
+	}
+
+	private boolean isNotBlank(String s) {
+		return s != null && !s.trim().isEmpty();
+	}
+
+	private boolean isItemDisabled(PerunFormItem formItem,
+	                             Map<Integer, ApplicationFormItemData> allItemsByIds) {
+		switch (formItem.getItemData().getFormItem().getDisabled()) {
+			case NEVER:
+				return false;
+			case ALWAYS:
+				return true;
+			case IF_EMPTY:
+				return isItemDisabledForValidator(formItem, allItemsByIds, this::isItemEmpty);
+			case IF_PREFILLED:
+				return isItemDisabledForValidator(formItem, allItemsByIds, this::isItemPrefilled);
+			default:
+				return false;
+		}
+	}
+
+	private boolean isItemHiddenForValidator(PerunFormItem formItemWithValue,
+	                                         Map<Integer, ApplicationFormItemData> allItemsByIds,
+	                                         Function<ApplicationFormItemData, Boolean> validator) {
+		ApplicationFormItem formItem = formItemWithValue.getItemData().getFormItem();
+
+		if (formItem.getHiddenDependencyItemId() == null) {
+			return validator.apply(allItemsByIds
+					.get(formItemWithValue.getItemData().getFormItem().getId()));
+		}
+		// READ - the parseInt(valueOf()) has to be used, otherwise no item is found - Sadly, I don't know why....
+		ApplicationFormItemData dependencyItem = allItemsByIds.get(Integer.parseInt(String.valueOf(formItem.getHiddenDependencyItemId())));
+		if (dependencyItem == null) {
+			return false;
+		} else {
+			return validator.apply(dependencyItem);
+		}
+	}
+	private boolean isItemDisabledForValidator(PerunFormItem formItemWithValue,
+	                                         Map<Integer, ApplicationFormItemData> allItemsByIds,
+	                                         Function<ApplicationFormItemData, Boolean> validator) {
+		ApplicationFormItem formItem = formItemWithValue.getItemData().getFormItem();
+
+		if (formItem.getDisabledDependencyItemId() == null) {
+			return validator.apply(allItemsByIds
+					.get(formItemWithValue.getItemData().getFormItem().getId()));
+		}
+
+		// READ - the parseInt(valueOf()) has to be used, otherwise no item is found - Sadly, I don't know why....
+		ApplicationFormItemData dependencyItem = allItemsByIds.get(Integer.parseInt(String.valueOf(formItem.getDisabledDependencyItemId())));
+		if (dependencyItem == null) {
+			return false;
+		} else {
+			return validator.apply(dependencyItem);
+		}
+	}
+
+	private boolean isItemEmpty(ApplicationFormItemData formItemWithValue) {
+		return formItemWithValue.getPrefilledValue() == null || formItemWithValue.getPrefilledValue().isEmpty();
+	}
+
+	private boolean isItemPrefilled(ApplicationFormItemData formItemWithValue) {
+		// For now, we support a special behaviour only for checkboxes
+		if (formItemWithValue.getFormItem().getType() == ApplicationFormItem.ApplicationFormItemType.CHECKBOX) {
+			return isCheckBoxPrefilled(formItemWithValue);
+		}
+		return isNotBlank(formItemWithValue.getPrefilledValue());
+	}
+
+	private boolean isCheckBoxPrefilled(ApplicationFormItemData formItemWithValue) {
+		if (isBlank(formItemWithValue.getPrefilledValue())) {
+			return false;
+		}
+		// This should probably be more sophisticated, but if the cs and en options have the same options, it should work
+		ApplicationFormItemTexts enTexts = formItemWithValue.getFormItem().getItemTexts("en");
+		if (enTexts == null) {
+			return false;
+		}
+		if (enTexts.getOptions() == null) {
+			 return false;
+		}
+		for (String option : enTexts.getOptions().split("\\|")) {
+			String value = option.split("#")[0];
+			if (formItemWithValue.getPrefilledValue().equals(value)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
 
 	private PerunFormItem generatePerunFormItem(ApplicationFormItemData data) {
 
 		String lang = PerunConfiguration.getCurrentLocaleName();
-
 		switch (data.getFormItem().getType()) {
 			case HEADING:
 				return new Header(form, data, lang);
@@ -81,7 +211,7 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 			case USERNAME:
 				Username username = new Username(form, data, lang);
 				if (data.getPrefilledValue() != null && !data.getPrefilledValue().isEmpty() && !data.isGenerated()) {
-					username.setEnable(false);
+					username.setEnabled(false);
 				}
 				return username;
 			case PASSWORD:
@@ -96,16 +226,6 @@ public class PerunFormItemsGeneratorImpl implements PerunFormItemsGenerator {
 				return new Checkbox(form, data, lang);
 			case RADIO:
 				return new Radiobox(form, data, lang);
-			case FROM_FEDERATION_SHOW:
-				return new FromFederation(form, data, lang);
-			case FROM_FEDERATION_HIDDEN:
-				FromFederation hidden = new FromFederation(form, data, lang);
-				if (!form.isSeeHiddenItems()) {
-					hidden.setVisible(false);
-				} else {
-					hidden.setRawStatus(new Icon(IconType.EYE_SLASH) + "  " + trans.federation(), ValidationState.NONE);
-				}
-				return hidden;
 			case HTML_COMMENT:
 				return new HtmlComment(form, data, lang);
 			case SUBMIT_BUTTON:

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Checkbox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Checkbox.java
@@ -28,10 +28,16 @@ public class Checkbox extends PerunFormItemEditable {
 	private final CheckboxValidator validator;
 
 	private FlowPanel widget;
+	private CheckBox checkBox;
 
 	public Checkbox(PerunForm form, ApplicationFormItemData item, String lang) {
 		super(form, item, lang);
 		this.validator = new CheckboxValidator();
+	}
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		this.checkBox.setEnabled(enabled);
 	}
 
 	@Override
@@ -47,7 +53,7 @@ public class Checkbox extends PerunFormItemEditable {
 
 		for (Map.Entry<String, String> entry : opts.entrySet()) {
 
-			CheckBox checkBox = new CheckBox(entry.getValue());
+			checkBox = new CheckBox(entry.getValue());
 			checkBox.setName(entry.getKey());
 			widget.add(checkBox);
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Combobox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Combobox.java
@@ -36,6 +36,13 @@ public class Combobox extends PerunFormItemEditable {
 
 	private Widget widget;
 
+	private Select select;
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		this.select.setEnabled(enabled);
+	}
+
 	public Combobox(PerunForm form, ApplicationFormItemData item, String lang) {
 		super(form, item, lang);
 		this.validator = new ComboboxValidator();
@@ -46,7 +53,7 @@ public class Combobox extends PerunFormItemEditable {
 
 		widget = new FlowPanel();
 
-		final Select select = new Select();
+		select = new Select();
 		select.setWidth("100%");
 		select.setShowTick(true);
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItem.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItem.java
@@ -3,11 +3,16 @@ package cz.metacentrum.perun.wui.registrar.widgets.items;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.ui.Widget;
 import cz.metacentrum.perun.wui.json.Events;
+import cz.metacentrum.perun.wui.model.beans.ApplicationFormItem;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemData;
 import cz.metacentrum.perun.wui.registrar.client.resources.PerunRegistrarTranslation;
 import cz.metacentrum.perun.wui.registrar.widgets.PerunForm;
 import cz.metacentrum.perun.wui.registrar.widgets.items.validators.PerunFormItemValidator;
 import org.gwtbootstrap3.client.ui.FormGroup;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Represents general form item. Encapsulate and view of ApplicationFormItemData returned from RPC.
@@ -21,6 +26,15 @@ public abstract class PerunFormItem extends FormGroup {
 	private PerunForm form;
 
 	PerunRegistrarTranslation translation;
+
+	Set<ApplicationFormItem.ApplicationFormItemType> notUpdatableTypes = new HashSet<>(Arrays.asList(
+		ApplicationFormItem.ApplicationFormItemType.USERNAME,
+		ApplicationFormItem.ApplicationFormItemType.PASSWORD,
+		ApplicationFormItem.ApplicationFormItemType.HEADING,
+		ApplicationFormItem.ApplicationFormItemType.HTML_COMMENT,
+		ApplicationFormItem.ApplicationFormItemType.SUBMIT_BUTTON,
+		ApplicationFormItem.ApplicationFormItemType.AUTO_SUBMIT_BUTTON
+	));
 
 	public PerunFormItem(PerunForm form, ApplicationFormItemData itemData, String lang) {
 		this.form = form;
@@ -145,7 +159,13 @@ public abstract class PerunFormItem extends FormGroup {
 	 * @return default TRUE
 	 */
 	public boolean isUpdatable() {
-		return getItemData().getFormItem() != null;
+		if (getItemData().getFormItem() == null) {
+			return false;
+		}
+		if (notUpdatableTypes.contains(getItemData().getFormItem().getType())) {
+			return false;
+		}
+		return getItemData().getFormItem().isUpdatable();
 	}
 
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/PerunFormItemEditable.java
@@ -190,6 +190,10 @@ public abstract class PerunFormItemEditable extends PerunFormItem {
 		return PerunForm.FormState.PREVIEW.equals(getForm().getFormState());
 	}
 
+	public void setEnabled(boolean enabled) {
+		// do nothing by default
+	}
+
 
 	/**
 	 * Status of item means validationState and text.

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextField.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextField.java
@@ -10,7 +10,9 @@ import cz.metacentrum.perun.wui.registrar.widgets.items.validators.PerunFormItem
 import cz.metacentrum.perun.wui.registrar.widgets.items.validators.TextFieldValidator;
 import cz.metacentrum.perun.wui.widgets.boxes.ExtendedTextBox;
 import org.gwtbootstrap3.client.ui.constants.ColumnSize;
+import org.gwtbootstrap3.client.ui.constants.ValidationState;
 import org.gwtbootstrap3.client.ui.html.Paragraph;
+import org.gwtbootstrap3.client.ui.html.Span;
 
 /**
  * Represents text field form item.
@@ -29,6 +31,12 @@ public class TextField extends PerunFormItemEditable {
 		this.validator = new TextFieldValidator();
 	}
 
+	@Override
+	public void setEnabled(boolean enabled) {
+		getBox().setEnabled(enabled);
+	}
+
+	@Override
 	protected Widget initWidget() {
 
 		widget = new ExtendedTextBox();
@@ -42,10 +50,16 @@ public class TextField extends PerunFormItemEditable {
 		return widget;
 	}
 
+	@Override
 	protected Widget initWidgetOnlyPreview() {
 
 		widget = new Paragraph();
 		getPreview().addStyleName("form-control");
+		if (getItemData() != null &&
+				getItemData().getFormItem() != null &&
+				getItemData().getFormItem().getFederationAttribute() != null) {
+			setRawStatus(getTranslation().federation(), ValidationState.NONE);
+		}
 		return widget;
 	}
 
@@ -101,11 +115,30 @@ public class TextField extends PerunFormItemEditable {
 
 	@Override
 	protected void setValueImpl(String value) {
-		if (isOnlyPreview()) {
-			getPreview().setText(value);
-			return;
+		// FIXME - We should implement value select for users
+
+		// if mail or organization, use only first value of multivalue attribute
+		if (getItemData() != null && getItemData().getFormItem() != null &&
+				("mail".equals(getItemData().getFormItem().getFederationAttribute()) ||
+						"o".equals(getItemData().getFormItem().getFederationAttribute()))) {
+
+			if (isOnlyPreview()) {
+
+				Span span = new Span();
+				span.setText(value.split(";")[0]);
+				getPreview().add(span);
+
+			} else {
+				getBox().setValue(value.split(";")[0]);
+			}
+
+		} else {
+			if (isOnlyPreview()) {
+				getPreview().setText(value);
+				return;
+			}
+			getBox().setValue(value);
 		}
-		getBox().setValue(value);
 	}
 
 
@@ -120,5 +153,10 @@ public class TextField extends PerunFormItemEditable {
 			return (Paragraph) widget;
 		}
 		return null;
+	}
+
+	@Override
+	public boolean isUpdatable() {
+		return getItemData().getFormItem() != null && getItemData().getFormItem().isUpdatable();
 	}
 }

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
@@ -29,6 +29,16 @@ public class Username extends PerunFormItemEditable {
 	private final UsernameValidator validator;
 
 	private InputGroup widget;
+	private ExtendedTextBox box;
+	private boolean enabled = true;
+
+	@Override
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+		if (this.box != null) {
+			this.box.setEnabled(enabled);
+		}
+	}
 
 	public Username(PerunForm form, ApplicationFormItemData item, String lang) {
 		super(form, item, lang);
@@ -43,7 +53,8 @@ public class Username extends PerunFormItemEditable {
 
 		InputGroupAddon addon = new InputGroupAddon();
 		addon.setIcon(IconType.USER);
-		ExtendedTextBox box = new ExtendedTextBox();
+		box = new ExtendedTextBox();
+		box.setEnabled(enabled);
 		box.setMaxLength(MAX_LENGTH);
 
 		if (getItemData().getFormItem().getRegex() != null) {
@@ -167,12 +178,7 @@ public class Username extends PerunFormItemEditable {
 	}
 
 	public ExtendedTextBox getTextBox() {
-		for (Widget box : getWidget()) {
-			if (box instanceof ExtendedTextBox) {
-				return (ExtendedTextBox) box;
-			}
-		}
-		return null;
+		return box;
 	}
 	public Paragraph getPreview() {
 		for (Widget box : getWidget()) {
@@ -181,10 +187,6 @@ public class Username extends PerunFormItemEditable {
 			}
 		}
 		return null;
-	}
-
-	public void setEnable(boolean enable) {
-		getTextBox().setEnabled(enable);
 	}
 
 	@Override

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
@@ -38,6 +38,12 @@ public class ValidatedEmail extends PerunFormItemEditable {
 
 	private InputGroup widget;
 
+	@Override
+	public void setEnabled(boolean enabled) {
+		getTextBox().setEnabled(enabled);
+		getSelect().setEnabled(enabled);
+	}
+
 	public ValidatedEmail(PerunForm form, ApplicationFormItemData item, String lang) {
 		super(form, item, lang);
 		this.validator = new ValidatedEmailValidator();


### PR DESCRIPTION
* Application form items have new properties - hidden, disabled and
updateable. The registrar GUI will now support these properties.
* Updatable - on the submitted application detail, it is now possible to
update only items, which are stated as updatable. There are some
exceptions, some types can never be updatable e.g. USERNAME.
* Hidden - items will be now hidden depending on their `hidden` value.
`ALWAYS` - item will never be displayed. `NEVER` - default behaviout,
item will be always visible. `IF_PREFILLED` item will be hidden, if it
is prefilled by the backend (or if `hidden_dependency` is specified, it
will be checked instead).
* Disabled - similar behaviour to the `hidden` property - the item will
be disabled depending on the specified condition.