### PR TITLE
Push back to Java 8 for GWT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,8 +21,8 @@
 
 	<!-- common environmental and version properties-->
 	<properties>
-		<maven.compiler.source>11</maven.compiler.source>
-		<maven.compiler.target>11</maven.compiler.target>
+		<maven.compiler.source>8</maven.compiler.source>
+		<maven.compiler.target>8</maven.compiler.target>
 
 		<!-- USE UTF-8 in whole project -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -77,7 +77,7 @@
 						</execution>
 					</executions>
 					<configuration>
-						<sourceLevel>1.11</sourceLevel>
+						<sourceLevel>1.8</sourceLevel>
 						<extraJvmArgs>--illegal-access=permit</extraJvmArgs>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
- During update to JDK 16 we updated also GWT compiler
  java version to 11. While its OK for compiling the app to
  production, we can't run app locally in development mode
  like that, since embedded Jetty server (9.2) doesn't support
  classes compiled with Java 11.
- Possible solution for update to Java 11 is part of
  pull-request #141, but its still WIP.