### PR TITLE
BugFix - username filed was always disabled

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Username.java
@@ -30,11 +30,9 @@ public class Username extends PerunFormItemEditable {
 
 	private InputGroup widget;
 	private ExtendedTextBox box;
-	private boolean enabled = true;
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		this.enabled = enabled;
 		if (this.box != null) {
 			this.box.setEnabled(enabled);
 		}
@@ -54,7 +52,6 @@ public class Username extends PerunFormItemEditable {
 		InputGroupAddon addon = new InputGroupAddon();
 		addon.setIcon(IconType.USER);
 		box = new ExtendedTextBox();
-		box.setEnabled(enabled);
 		box.setMaxLength(MAX_LENGTH);
 
 		if (getItemData().getFormItem().getRegex() != null) {


### PR DESCRIPTION
* There was a problem with the `enabled` property of the `Username`
object. The value of this property was set to true, when instance of
this class was created. This property was used in the `initWidget` method.
The `initWidget` method was called from a constructor of a super class
and that was a problem. When the super constructor was called, variables
declared in the `Username` class were not initalized. Therefore, the
`enabled` property had the default value - false.
* This caused the username to be always disabled.
* I discovered that the property was not actually needed, co the fix is
just to remove it.