### PR TITLE
Added handling for invalid pref mail requests

### DIFF
--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation.java
@@ -415,4 +415,6 @@ public interface PerunProfileTranslation extends PerunTranslation {
 	@DefaultMessage("E-mail address {0} was verified and set as your preferred e-mail.")
 	String verifyingEmailChangeDone(String email);
 
+	@DefaultMessage("Preferred email change requested doesn't exist or isn't valid anymore.")
+	String mailChangeError();
 }

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.java
@@ -2,13 +2,12 @@ package cz.metacentrum.perun.wui.profile.pages.personal;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.dom.client.Style;
-import com.google.gwt.event.dom.client.ClickEvent;
-import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.json.client.JSONValue;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiField;
 import com.google.gwt.user.cellview.client.TextColumn;
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.inject.Inject;
 import com.gwtplatform.mvp.client.ViewWithUiHandlers;
@@ -107,6 +106,8 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 	PerunLoader verifyEmailLoader;
 	@UiField
 	Button doneButton;
+	@UiField
+	Alert mailChangeError;
 
 	@Inject
 	public PersonalView(PersonalViewUiBinder binder) {
@@ -127,6 +128,8 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 		updateEmailBtn.setText(translation.sendValidationEmail());
 		updateEmailModal.setTitle(translation.updateEmailModalTitle());
 		updateEmailLabel.setText(translation.newPreferredEmail());
+
+		doneButton.addClickHandler(clickEvent -> Window.Location.replace(Window.Location.getPath()));
 	}
 
 	private void loadAttributeNamesTranslations() {
@@ -244,12 +247,9 @@ public class PersonalView extends ViewWithUiHandlers<PersonalUiHandlers> impleme
 	@Override
 	public void verifyEmailChangeError(PerunException ex) {
 		doneButton.setEnabled(true);
-		verifyEmailLoader.onError(ex, new ClickHandler() {
-			@Override
-			public void onClick(ClickEvent clickEvent) {
-				getUiHandlers().verifyEmail();
-			}
-		});
+		mailChangeError.setVisible(true);
+		mailChangeError.setText(translation.mailChangeError());
+		verifyEmailLoader.setVisible(false);
 	}
 
 	@Override

--- a/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.ui.xml
+++ b/perun-wui-profile/src/main/java/cz/metacentrum/perun/wui/profile/pages/personal/PersonalView.ui.xml
@@ -53,6 +53,7 @@
 		<b:Modal title="Verify preferred e-mail" ui:field="verifyEmailModal" closable="true" fade="true" dataBackdrop="STATIC" dataKeyboard="true" b:id="verifyEmailModal">
 			<b:ModalBody>
 				<p:PerunLoader ui:field="verifyEmailLoader" />
+				<b:Alert dismissable="false" ui:field="mailChangeError" type="DANGER" visible="false" />
 			</b:ModalBody>
 			<b:ModalFooter>
 				<b:Button ui:field="doneButton" enabled="false" type="PRIMARY" dataDismiss="MODAL" dataTarget="verifyEmailModal">OK</b:Button>

--- a/perun-wui-profile/src/main/resources/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation_cs.properties
+++ b/perun-wui-profile/src/main/resources/cz/metacentrum/perun/wui/profile/client/resources/PerunProfileTranslation_cs.properties
@@ -136,3 +136,4 @@ sambaPasswordSetNotif=Heslo pro službu SAMBA bylo změněno.
 verifyEmailChangeTitle=Ověření preferovaného e-mailu
 verifyingEmailChange=Probíhá ověření
 verifyingEmailChangeDone=E-mailová adresa {0} byla ověřena a nastavena jako Váš preferovaný e-mail.
+mailChangeError=Žádost o změnu preferovaného emailu neexistuje nebo již není platná.


### PR DESCRIPTION
* Preferred mail is changed after redirecting to the profile, query parameters are cleared
* If the request isn't valid anymore or doesn't exist, modal with info is displayed