### PR TITLE
Increase size limit for TextArea form items

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextArea.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/TextArea.java
@@ -18,7 +18,7 @@ import org.gwtbootstrap3.client.ui.html.Paragraph;
  */
 public class TextArea extends PerunFormItemEditable {
 
-	public final static int MAX_LENGTH = 3999;
+	public final static int MAX_LENGTH = 10000;
 	private final TextAreaValidator validator;
 
 	private Widget widget;


### PR DESCRIPTION
- We formerly limited size of user input in TextArea form items to 3999,
  because we were limited by Oracle DB. Now we use postgres, which can
  take up to 1GB. We don't want users to upload so much, but
  limit was increased to 10 000 chars.