### PR TITLE
 feat(registrar): reload data when moving to group application form

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/GroupInitStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/GroupInitStep.java
@@ -32,12 +32,8 @@ public class GroupInitStep extends FormStep {
 		events.onLoadingStart();
 		this.localPP = pp;
 
-		// if there is a VoInitForm then there should be previous step where user submitted VO init application
-		// it it`s in an auto-approval mode, then User might have been created and we want to reflect this in
-		// group application, hence we will forcefully reload its form and session info.
-		if (!registrar.getVoFormInitial().isEmpty() &&
-				registrar.getVoFormInitialException() == null &&
-				registrar.hasVoFormAutoApproval()) {
+		// reload user data for group application
+		if (!registrar.getVoFormInitial().isEmpty() &&	registrar.getVoFormInitialException() == null) {
 
 			reloadGroupAppData(new JsonEvents() {
 				@Override


### PR DESCRIPTION
* When moving to group application from vo application we want to reload group application form
every time, because user might have filled-in data to vo application that we want to prefill to
group application. Till now both forms were loaded beforehand and vo application data would not be
used.