### PR TITLE
fix(registrar): fix app view with disabled email

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/ValidatedEmail.java
@@ -40,8 +40,12 @@ public class ValidatedEmail extends PerunFormItemEditable {
 
 	@Override
 	public void setEnabled(boolean enabled) {
-		getTextBox().setEnabled(enabled);
-		getSelect().setEnabled(enabled);
+		if (getTextBox() != null) {
+			getTextBox().setEnabled(enabled);
+		}
+		if (getSelect() != null) {
+			getSelect().setEnabled(enabled);
+		}
 	}
 
 	public ValidatedEmail(PerunForm form, ApplicationFormItemData item, String lang) {


### PR DESCRIPTION
* If there was an application where was a disabled VALIDATED_EMAIL item, the preview would not be
displayed, because of an error. The setEnabled method expected the textBox to exist. However, on a
preview, there was no textBox, there was only a paragraph.