### PR TITLE
build: allow overriding JVM used for GWT compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,8 @@
 						</execution>
 					</executions>
 					<configuration>
+						<!-- Allow to override used JVM for this project if system Java > 16 -->
+						<jvm>${JAVA_HOME_16}</jvm>
 						<sourceLevel>1.8</sourceLevel>
 						<extraJvmArgs>--illegal-access=permit</extraJvmArgs>
 					</configuration>


### PR DESCRIPTION
- Used libraries in WUI are too old and can't be build
  using Java > 16.
- Introduced JAVA_HOME_16 variable used to specify path
  to Java 16 from outside as it might not be default Java
  version used in the build environment (we are moving
  to Java 17 with the rest of perun project).