### PR TITLE
remove perun-wui-admin from build and release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -17,7 +17,6 @@
     }],
     ["@semantic-release/github", {
       "assets": [
-        {"path": "perun-wui-admin/target/perun-wui-admin.war"},
         {"path": "perun-wui-registrar/target/perun-wui-registrar.war"},
         {"path": "perun-wui-consolidator/target/perun-wui-consolidator.war"},
         {"path": "perun-wui-pwdreset/target/perun-wui-pwdreset.war"},

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
 	<!-- PERUN MODULES -->
 	<modules>
 		<module>perun-wui-core</module>
-		<module>perun-wui-admin</module>
 		<module>perun-wui-registrar</module>
 		<module>perun-wui-consolidator</module>
 		<module>perun-wui-pwdreset</module>


### PR DESCRIPTION
- Module perun-wui-admin was removed from build and release because it
is not used.