### PR TITLE
feat(pwd-reset): display custom messages for einfra

### DIFF
--- a/perun-wui-pwdreset/src/main/java/cz/metacentrum/perun/wui/pwdreset/client/resources/PerunPwdResetTranslation.java
+++ b/perun-wui-pwdreset/src/main/java/cz/metacentrum/perun/wui/pwdreset/client/resources/PerunPwdResetTranslation.java
@@ -70,7 +70,7 @@ public interface PerunPwdResetTranslation extends PerunTranslation {
 
 	// -------------- ACTIVATE ACCOUNT TRANSLATION ------------------------ //
 
-	@DefaultMessage("Activate account")
+	@DefaultMessage("Account activation")
 	public String activateAppName();
 
 	@DefaultMessage("Activate account for {0}")
@@ -79,13 +79,28 @@ public interface PerunPwdResetTranslation extends PerunTranslation {
 	@DefaultMessage("Activate account")
 	public String submitActivateButton();
 
-	@DefaultMessage("Account is active.")
-	public String activateSuccess();
+	@DefaultMessage("Your {0} account has been activated.")
+	public String activateSuccess(String namespace);
 
 	@DefaultMessage("Account activation in a namespace <i>{0}</i> is not supported.")
 	public String namespaceNotSupportedActive(String namespace);
 
 	@DefaultMessage("Can`t activate account. You don`t have login in namespace <i>{0}</i>.")
 	public String dontHaveLoginActive(String namespace);
+
+	@DefaultMessage("<h4>Your password in e-INFRA CZ has already been activated</h4><br/><p>Setting your password may be delayed in some services (about 10 minutes).<p><b>In IT4I services, the delay can be up to 1 hour.</b> It is also <b>necessary to wait for the final confirmation of the account migration by IT4I</b>. Until then, the original password is valid within IT4I.<p>If the previous conditions have been met and your password is still not working, please contact support at <a href=\"mailto:{0}\">{0}</a>.")
+	public String alreadyActivated(String mailto);
+
+	@DefaultMessage("<h4>Password for e-INFRA CZ account has been activated</h4><br/><p>New password will be reflected in e-INFRA CZ and CESNET services within 10 minutes.<p><b>It may take up to 1 hour to take effect within the IT4I services.</b> At the same time, <b>the change will not take effect until you receive a final confirmation from IT4I that the account migration has been completed</b> and linked to your e-INFRA CZ account. In the meantime, the original password is valid within IT4I services.<p>You can now close the browser window.")
+	public String activationSuccessEinfra();
+
+	@DefaultMessage("Password activation for an account {0} at e-INFRA CZ")
+	public String activateForEinfra(String login);
+
+	@DefaultMessage("Activate password")
+	public String submitActivateButtonEinfra();
+
+	@DefaultMessage("<p>To complete the import of your account from IT4I to the e-INFRA CZ common e-infrastructure, you need to set a password.")
+	public String explanation();
 
 }

--- a/perun-wui-pwdreset/src/main/java/cz/metacentrum/perun/wui/pwdreset/pages/PwdResetView.ui.xml
+++ b/perun-wui-pwdreset/src/main/java/cz/metacentrum/perun/wui/pwdreset/pages/PwdResetView.ui.xml
@@ -29,6 +29,8 @@
 
 					<p:PerunLoader ui:field="loader" visible="true" />
 
+					<b.html:Paragraph ui:field="infoAlert" visible="false" marginTop="20" addStyleNames="col-lg-10 col-sm-10 col-xs-10" />
+
 					<b:Form ui:field="form" visible="false" addStyleNames="col-lg-7 col-md-8 col-sm-8 col-xs-12">
 						<b:FieldSet marginTop="50">
 

--- a/perun-wui-pwdreset/src/main/resources/cz/metacentrum/perun/wui/pwdreset/client/resources/PerunPwdResetTranslation_cs.properties
+++ b/perun-wui-pwdreset/src/main/resources/cz/metacentrum/perun/wui/pwdreset/client/resources/PerunPwdResetTranslation_cs.properties
@@ -26,6 +26,11 @@ passwordStrength4=Heslo musí obsahovat znaky minimálně ze tří sad znaků: {
 activateAppName=Aktivace účtu
 activateFor=Aktivovat účet pro {0}
 submitActivateButton=Aktivovat účet
-activateSuccess=Váš účet je nyní aktivní.
+activateSuccess=Váš účet v {0} byl aktivován.
 namespaceNotSupportedActive=Aktivace účtu ve jmenném prostoru <i>{0}</i> není podporována.
 dontHaveLoginActive=Nelze aktivovat účet. Nemáte login ve jmenném prostoru <i>{0}</i>.
+alreadyActivated=<h4>Vaše heslo v e-INFRA CZ již bylo aktivováno</h4><br/><p>Nastavení hesla se v některých službách může projevit se zpožděním (cca 10 minut).<p><b>V rámci služeb IT4I může být zpoždění do 1 hodiny.</b> Zároveň platí, že <b>je nutné počkat na finální potvrzení o migraci účtu ze strany IT4I</b>. Do té doby v rámci IT4I platí původní heslo. <p>Pokud byly předchozí podmínky splněny a Vaše heslo stále není funkční, kontaktujte prosím podporu na <a href="mailto:{0}">{0}</a>.
+activationSuccessEinfra=<h4>Heslo pro e-INFRA CZ účet bylo aktivováno</h4><br/><p>Nastavení hesla se v rámci služeb e-INFRA CZ a CESNETu projeví nejpozději do 10 minut.<p><b>Nastavení hesla se v rámci služeb IT4I může projevit se zpožděním do 1 hodiny.</b> Zároveň platí, že se změna projeví <b>nejdříve poté, co Vám ze strany IT4I přijde finální potvrzení o ukončení migrace účtu</b> a jeho propojení s e-INFRA CZ účtem. Do té doby platí v rámci IT4I služeb původní heslo.<p>Nyní můžete okno prohlížeče zavřít.
+activateForEinfra=Aktivace hesla pro účet {0} v e-INFRA CZ
+submitActivateButtonEinfra=Aktivovat heslo
+explanation=<p>Pro dokončení importu Vašeho účtu z IT4I do společné e-infrastruktury e-INFRA CZ je potřeba nastavit heslo.


### PR DESCRIPTION
- Check if account has been activated and prevent repetitive activation.
- Display custom texts when its activation and einfra namespace for
  both success and error messages.
- Custom messages are active only for /it4i/ prefix, since they mention
  account migration/import.