### PR TITLE
fix(registrar): return empty value if no option selected in selectbox

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Selectionbox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/Selectionbox.java
@@ -43,7 +43,7 @@ public class Selectionbox extends PerunFormItemEditable {
 		getSelect().clear();
 
 		if (!isRequired()) {
-			getSelect().addItem(translation.notSelected(), (String) null);
+			getSelect().addItem(translation.notSelected(), "");
 		}
 
 		Map<String, String> opts = parseItemOptions();


### PR DESCRIPTION
- Previously generic "--- Not selected ---" option in the select box returned
  "null" string value.
- Now we return empty string which is correctly recognized as an empty/null
  value for the attribute on Perun side.
- This prevents bug when such value should be stored in attribute
  with checked syntax.