### PR TITLE
ci: use conventional commits preset for release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,6 +5,7 @@
     { "name": "alpha", "prerelease": true },
     { "name": "beta", "prerelease": true }
   ],
+  "preset": "conventionalcommits",
   "plugins": [
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",


### PR DESCRIPTION
* release is otherwise not triggered when commit containing breaking change marked with exclamation mark is merged