### PR TITLE
fix: 🐛 Add `PasswordProtectedTransport` to IdP hint ACRs

### DIFF
--- a/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/widgets/Wayf.java
+++ b/perun-wui-consolidator/src/main/java/cz/metacentrum/perun/wui/consolidator/widgets/Wayf.java
@@ -117,7 +117,7 @@ public class Wayf extends Composite {
 
 						// TODO - we won't support template in a future
 						String consolidatorUrl = Utils.getIdentityConsolidatorLink(group.getUrl(), false) + URL.encodeQueryString("?token=" + token + target);
-						String authnContextClassRef = "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified%20urn:cesnet:proxyidp:template:cesnet";
+						String authnContextClassRef = "urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified%20urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport%20urn:cesnet:proxyidp:template:cesnet";
 
 						// button is single IdP - pass it to the proxy
 						if (group.getIdpEntityID() != null && !group.getIdpEntityID().isEmpty()) {

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/FormView.java
@@ -689,7 +689,7 @@ public class FormView extends ViewImpl implements FormPresenter.MyView {
 										// FINAL URL must logout from SP, login to SP using specified IdP, redirect to IC and after that return to application form
 										String token = ((BasicOverlayObject) jso).getString();
 										String consolidatorUrl = Utils.getIdentityConsolidatorLink("fed", true) + URL.encodeQueryString("&token=" + token);
-										String redirectUrl = PerunConfiguration.getWayfSpLogoutUrl() + "?return=" + PerunConfiguration.getWayfSpLoginUrl() + URL.encodeQueryString("?authnContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified%20urn:cesnet:proxyidp:template:cesnet%20urn:cesnet:proxyidp:idpentityid:" + finalEntityId + "&target=" + consolidatorUrl);
+										String redirectUrl = PerunConfiguration.getWayfSpLogoutUrl() + "?return=" + PerunConfiguration.getWayfSpLoginUrl() + URL.encodeQueryString("?authnContextClassRef=urn:oasis:names:tc:SAML:2.0:ac:classes:unspecified%20urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport%20urn:cesnet:proxyidp:template:cesnet%20urn:cesnet:proxyidp:idpentityid:" + finalEntityId + "&target=" + consolidatorUrl);
 										Window.Location.assign(redirectUrl);
 									}
 


### PR DESCRIPTION
Missing AuthenticationContextClassRef Caused some IdPs to fail. They do not understand the `unspecified` value, nor do they understand the IdP Hint, if it somehow got forwarded (e.g. LS AAI case). With this tweak, even if it gets forwarded, IdP can respond with
`urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport` and will not fail.