### PR TITLE
fix: 🐛 Different default error msg for inputs like radio, check

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation.java
@@ -139,6 +139,9 @@ public interface PerunRegistrarTranslation extends PerunTranslation {
 	@DefaultMessage("You must select at least one option!")
 	public String cantBeEmptyCheckBox();
 
+	@DefaultMessage("You must check this box!")
+	public String cantBeEmptySingleCheckBox();
+
 	@DefaultMessage("Incorrect email address format!")
 	public String incorrectEmail();
 

--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/validators/CheckboxValidator.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/validators/CheckboxValidator.java
@@ -24,7 +24,11 @@ public class CheckboxValidator extends PerunFormItemValidatorImpl<Checkbox> {
 			} else {
 				// single checkbox - prefer own error message
 				setResult(Result.EMPTY);
-				checkbox.setRawStatus(getErrorMsgOrDefault(checkbox), ValidationState.ERROR);
+				String msg = getErrorMsgOrDefault(checkbox);
+				if (msg.equals(getTransl().incorrectFormat())) {
+					msg = getTransl().cantBeEmptySingleCheckBox();
+				}
+				checkbox.setRawStatus(msg, ValidationState.ERROR);
 			}
 			return false;
 		}

--- a/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
+++ b/perun-wui-registrar/src/main/resources/cz/metacentrum/perun/wui/registrar/client/resources/PerunRegistrarTranslation_cs.properties
@@ -55,6 +55,7 @@ duplicateKeys=Každý klíč musí být unikátní!
 cantBeEmpty=Položka <b>nesmí být prázdná!</b>
 cantBeEmptySelect=Musíte vybrat jednu z možností!
 cantBeEmptyCheckBox=Musíte vybrat alespoň jednu možnost!
+cantBeEmptySingleCheckBox=Tuhle položku musíte označit!
 incorrectEmail=Neplatný formát e-mailové adresy!
 checkAndSubmit=Zkontrolovat a odeslat formulář
 passEmpty=Heslo <b>nesmí být prázdné!</b>


### PR DESCRIPTION
Provide more meaningful default error messages for inputs that do not have format, e.g. radio, checkbox, select, embedded_gr_app.