### PR TITLE
fix(registrar): use shorter names of ebmedded groups withou prefix

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/GroupCheckBox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/GroupCheckBox.java
@@ -1,5 +1,6 @@
 package cz.metacentrum.perun.wui.registrar.widgets.items;
 
+import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.ui.Widget;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemData;
 import cz.metacentrum.perun.wui.model.beans.ApplicationFormItemTexts;
@@ -23,6 +24,25 @@ public class GroupCheckBox extends Checkbox {
 	}
 
 	private boolean preview = false;
+
+	@Override
+	protected Widget initWidget() {
+		super.initWidget();
+
+		boolean isGroupApplication = Window.Location.getParameter("group") != null;
+		if (isGroupApplication) {
+			for (Widget widget : getWidget()) {
+				if (widget instanceof CheckBox) {
+					CheckBox checkBox = (CheckBox) widget;
+					String[] parsedGroupName = checkBox.getText().split(Window.Location.getParameter("group") + ":");
+					// use group name without parent group prefix
+					checkBox.setText(parsedGroupName[1]);
+				}
+			}
+		}
+
+		return getWidget();
+	}
 
 	@Override
 	protected Widget initWidgetOnlyPreview() {


### PR DESCRIPTION
* Use the group names in embedded group form item (for group) without prefix.
* This change is applied only for group forms.