### PR TITLE
fix: 🐛 Redirect user back to service after modal closes

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/pages/steps/SummaryStep.java
@@ -861,9 +861,8 @@ public class SummaryStep implements Step {
 				modal.setClosable(false);
 				modal.setWidth("750px");
 
-
 				Button button = new Button(translation.understand());
-				button.setType(ButtonType.PRIMARY);
+				button.setType(ButtonType.DEFAULT);
 				button.addClickHandler(new ClickHandler() {
 					@Override
 					public void onClick(ClickEvent event) {
@@ -871,8 +870,19 @@ public class SummaryStep implements Step {
 					}
 				});
 
+				Button buttonContAnyway = new Button(translation.continueAnyway());
+				buttonContAnyway.setType(ButtonType.PRIMARY);
+				buttonContAnyway.addClickHandler(new ClickHandler() {
+					@Override
+					public void onClick(ClickEvent event) {
+						modal.hide();
+						redirectAfterTimeout(redirectTo);
+					}
+				});
+
 				ModalFooter footer = new ModalFooter();
 				footer.add(button);
+				footer.add(buttonContAnyway);
 
 				ModalBody body = new ModalBody();
 				modal.add(body);


### PR DESCRIPTION
Fixed version redirect user back to the service after the modal window is closed. Previous implementation caused users to be stuck on opening the modal window informing them that the application is not processed and the service might redirect them back to this reg. form. However, this causes problems if users are redirected somewhere else, e.g. homepage of the service.