### PR TITLE
fix: override checkbox text only if not empty

### DIFF
--- a/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/GroupCheckBox.java
+++ b/perun-wui-registrar/src/main/java/cz/metacentrum/perun/wui/registrar/widgets/items/GroupCheckBox.java
@@ -35,8 +35,10 @@ public class GroupCheckBox extends Checkbox {
 				if (widget instanceof CheckBox) {
 					CheckBox checkBox = (CheckBox) widget;
 					String[] parsedGroupName = checkBox.getText().split(Window.Location.getParameter("group") + ":");
-					// use group name without parent group prefix
-					checkBox.setText(parsedGroupName[1]);
+					// use group name without parent group prefix only if there is one
+					if (parsedGroupName[1] != null) {
+						checkBox.setText(parsedGroupName[1]);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- Override text on checkboxes for embedded group applications only if resulting value is not empty.
- Behavior depends on the presence of group param in URL query and its value.